### PR TITLE
[1차 스프린트 - User] 기본 프로필 작성 기능 구현

### DIFF
--- a/src/main/java/dev/steady/auth/domain/Account.java
+++ b/src/main/java/dev/steady/auth/domain/Account.java
@@ -46,4 +46,10 @@ public class Account {
         return this.user == null;
     }
 
+    public void registerUser(User user) {
+        if (this.hasNoUser()) {
+            this.user = user;
+        }
+    }
+
 }

--- a/src/main/java/dev/steady/auth/service/AccountService.java
+++ b/src/main/java/dev/steady/auth/service/AccountService.java
@@ -1,0 +1,27 @@
+package dev.steady.auth.service;
+
+import dev.steady.auth.domain.Account;
+import dev.steady.auth.domain.repository.AccountRepository;
+import dev.steady.user.domain.User;
+import dev.steady.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+
+    private final AccountRepository accountRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void registerUser(Long accountId, Long userId) {
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(IllegalArgumentException::new);
+        User user = userRepository.findById(userId)
+                .orElseThrow(IllegalArgumentException::new);
+        account.registerUser(user);
+    }
+
+}

--- a/src/main/java/dev/steady/user/domain/User.java
+++ b/src/main/java/dev/steady/user/domain/User.java
@@ -22,6 +22,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
+    private static final String DEFAULT_PROFILE_IMAGE_URL = "default_profile_image_url.jpg";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -47,4 +49,10 @@ public class User {
         this.position = position;
     }
 
+    public User(String nickname, Position position) {
+        this.nickname = nickname;
+        this.position = position;
+        this.profileImage = DEFAULT_PROFILE_IMAGE_URL;
+    }
+    
 }

--- a/src/main/java/dev/steady/user/domain/UserStack.java
+++ b/src/main/java/dev/steady/user/domain/UserStack.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "user_stack")
+@Table(name = "user_stacks")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserStack {
 

--- a/src/main/java/dev/steady/user/domain/UserStack.java
+++ b/src/main/java/dev/steady/user/domain/UserStack.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,8 +27,7 @@ public class UserStack {
     @ManyToOne(fetch = FetchType.LAZY)
     private Stack stack;
 
-    @Builder
-    private UserStack(User user, Stack stack) {
+    public UserStack(User user, Stack stack) {
         this.user = user;
         this.stack = stack;
     }

--- a/src/main/java/dev/steady/user/domain/repository/UserRepository.java
+++ b/src/main/java/dev/steady/user/domain/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
                 .orElseThrow(IllegalArgumentException::new);
     }
 
+    Boolean existsByNickname(String nickname);
+    
 }

--- a/src/main/java/dev/steady/user/domain/repository/UserRepository.java
+++ b/src/main/java/dev/steady/user/domain/repository/UserRepository.java
@@ -10,6 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
                 .orElseThrow(IllegalArgumentException::new);
     }
 
-    Boolean existsByNickname(String nickname);
-    
+    boolean existsByNickname(String nickname);
+
 }

--- a/src/main/java/dev/steady/user/domain/repository/UserStackRepository.java
+++ b/src/main/java/dev/steady/user/domain/repository/UserStackRepository.java
@@ -1,0 +1,12 @@
+package dev.steady.user.domain.repository;
+
+import dev.steady.user.domain.UserStack;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserStackRepository extends JpaRepository<UserStack, Long> {
+
+    List<UserStack> findAllByUserId(Long userId);
+
+}

--- a/src/main/java/dev/steady/user/dto/request/CreateUserRequest.java
+++ b/src/main/java/dev/steady/user/dto/request/CreateUserRequest.java
@@ -1,0 +1,18 @@
+package dev.steady.user.dto.request;
+
+import dev.steady.user.domain.Position;
+import dev.steady.user.domain.User;
+
+import java.util.List;
+
+public record CreateUserRequest(
+        Long accountId,
+        String nickname,
+        Long positionId,
+        List<Long> stackIds
+) {
+    public User toEntity(Position position) {
+        return new User(this.nickname, position);
+    }
+
+}

--- a/src/main/java/dev/steady/user/dto/request/CreateUserRequest.java
+++ b/src/main/java/dev/steady/user/dto/request/CreateUserRequest.java
@@ -11,6 +11,7 @@ public record CreateUserRequest(
         Long positionId,
         List<Long> stackIds
 ) {
+    
     public User toEntity(Position position) {
         return new User(this.nickname, position);
     }

--- a/src/main/java/dev/steady/user/dto/request/UserCreateRequest.java
+++ b/src/main/java/dev/steady/user/dto/request/UserCreateRequest.java
@@ -5,13 +5,13 @@ import dev.steady.user.domain.User;
 
 import java.util.List;
 
-public record CreateUserRequest(
+public record UserCreateRequest(
         Long accountId,
         String nickname,
         Long positionId,
         List<Long> stackIds
 ) {
-    
+
     public User toEntity(Position position) {
         return new User(this.nickname, position);
     }

--- a/src/main/java/dev/steady/user/presentation/UserController.java
+++ b/src/main/java/dev/steady/user/presentation/UserController.java
@@ -4,9 +4,11 @@ import dev.steady.auth.service.AccountService;
 import dev.steady.user.dto.request.CreateUserRequest;
 import dev.steady.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,5 +26,10 @@ public class UserController {
 
         return userId;
     }
-    
+
+    @GetMapping("/profile/exist")
+    public Boolean existsByNickname(@RequestParam String nickname) {
+        return userService.existsByNickname(nickname);
+    }
+
 }

--- a/src/main/java/dev/steady/user/presentation/UserController.java
+++ b/src/main/java/dev/steady/user/presentation/UserController.java
@@ -28,7 +28,7 @@ public class UserController {
     }
 
     @GetMapping("/profile/exist")
-    public Boolean existsByNickname(@RequestParam String nickname) {
+    public boolean existsByNickname(@RequestParam String nickname) {
         return userService.existsByNickname(nickname);
     }
 

--- a/src/main/java/dev/steady/user/presentation/UserController.java
+++ b/src/main/java/dev/steady/user/presentation/UserController.java
@@ -1,0 +1,28 @@
+package dev.steady.user.presentation;
+
+import dev.steady.auth.service.AccountService;
+import dev.steady.user.dto.request.CreateUserRequest;
+import dev.steady.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserController {
+
+    private final UserService userService;
+    private final AccountService accountService;
+
+    @PostMapping("/profile")
+    public Long createUser(@RequestBody CreateUserRequest request) {
+        Long userId = userService.createUser(request);
+        accountService.registerUser(request.accountId(), userId);
+
+        return userId;
+    }
+    
+}

--- a/src/main/java/dev/steady/user/presentation/UserController.java
+++ b/src/main/java/dev/steady/user/presentation/UserController.java
@@ -1,7 +1,7 @@
 package dev.steady.user.presentation;
 
 import dev.steady.auth.service.AccountService;
-import dev.steady.user.dto.request.CreateUserRequest;
+import dev.steady.user.dto.request.UserCreateRequest;
 import dev.steady.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +20,7 @@ public class UserController {
     private final AccountService accountService;
 
     @PostMapping("/profile")
-    public Long createUser(@RequestBody CreateUserRequest request) {
+    public Long createUser(@RequestBody UserCreateRequest request) {
         Long userId = userService.createUser(request);
         accountService.registerUser(request.accountId(), userId);
 

--- a/src/main/java/dev/steady/user/service/UserService.java
+++ b/src/main/java/dev/steady/user/service/UserService.java
@@ -42,9 +42,15 @@ public class UserService {
         return userRepository.existsByNickname(nickname);
     }
 
-    private List<Stack> getStacks(List<Long> stackIds) {
+    @Transactional(readOnly = true)
+    public Stack getStack(Long stackId) {
+        return stackRepository.findById(stackId).orElseThrow(IllegalArgumentException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Stack> getStacks(List<Long> stackIds) {
         return stackIds.stream()
-                .map(stackId -> stackRepository.findById(stackId).orElseThrow(IllegalArgumentException::new))
+                .map(this::getStack)
                 .toList();
     }
 

--- a/src/main/java/dev/steady/user/service/UserService.java
+++ b/src/main/java/dev/steady/user/service/UserService.java
@@ -1,0 +1,56 @@
+package dev.steady.user.service;
+
+import dev.steady.user.domain.Position;
+import dev.steady.user.domain.Stack;
+import dev.steady.user.domain.User;
+import dev.steady.user.domain.UserStack;
+import dev.steady.user.domain.repository.PositionRepository;
+import dev.steady.user.domain.repository.StackRepository;
+import dev.steady.user.domain.repository.UserRepository;
+import dev.steady.user.domain.repository.UserStackRepository;
+import dev.steady.user.dto.request.CreateUserRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final StackRepository stackRepository;
+    private final PositionRepository positionRepository;
+    private final UserStackRepository userStackRepository;
+
+    @Transactional
+    public Long createUser(CreateUserRequest request) {
+        Position position = getPosition(request.positionId());
+
+        User user = request.toEntity(position);
+        User savedUser = userRepository.save(user);
+
+        List<UserStack> userStacks = createUserStacks(request.stackIds(), savedUser);
+        userStackRepository.saveAll(userStacks);
+
+        return savedUser.getId();
+    }
+
+    private List<Stack> getStacks(List<Long> stackIds) {
+        return stackIds.stream()
+                .map(stackId -> stackRepository.findById(stackId).orElseThrow(IllegalArgumentException::new))
+                .toList();
+    }
+
+    private Position getPosition(Long positionId) {
+        return positionRepository.findById(positionId).orElseThrow(IllegalArgumentException::new);
+    }
+
+    private List<UserStack> createUserStacks(List<Long> stackIds, User user) {
+        List<Stack> stacks = getStacks(stackIds);
+        return stacks.stream().map(stack -> new UserStack(user, stack)).toList();
+    }
+
+}

--- a/src/main/java/dev/steady/user/service/UserService.java
+++ b/src/main/java/dev/steady/user/service/UserService.java
@@ -63,7 +63,10 @@ public class UserService {
     @Transactional
     public List<UserStack> createUserStacks(List<Long> stackIds, User user) {
         List<Stack> stacks = getStacks(stackIds);
-        return stacks.stream().map(stack -> new UserStack(user, stack)).toList();
+        List<UserStack> userStacks = stacks.stream()
+                .map(stack -> new UserStack(user, stack))
+                .toList();
+        return userStacks;
     }
 
 }

--- a/src/main/java/dev/steady/user/service/UserService.java
+++ b/src/main/java/dev/steady/user/service/UserService.java
@@ -38,7 +38,7 @@ public class UserService {
         return savedUser.getId();
     }
 
-    public Boolean existsByNickname(String nickname) {
+    public boolean existsByNickname(String nickname) {
         return userRepository.existsByNickname(nickname);
     }
 

--- a/src/main/java/dev/steady/user/service/UserService.java
+++ b/src/main/java/dev/steady/user/service/UserService.java
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserService {
 
@@ -38,6 +37,7 @@ public class UserService {
         return savedUser.getId();
     }
 
+    @Transactional(readOnly = true)
     public boolean existsByNickname(String nickname) {
         return userRepository.existsByNickname(nickname);
     }
@@ -54,11 +54,14 @@ public class UserService {
                 .toList();
     }
 
-    private Position getPosition(Long positionId) {
-        return positionRepository.findById(positionId).orElseThrow(IllegalArgumentException::new);
+    @Transactional(readOnly = true)
+    public Position getPosition(Long positionId) {
+        return positionRepository.findById(positionId)
+                .orElseThrow(IllegalArgumentException::new);
     }
 
-    private List<UserStack> createUserStacks(List<Long> stackIds, User user) {
+    @Transactional
+    public List<UserStack> createUserStacks(List<Long> stackIds, User user) {
         List<Stack> stacks = getStacks(stackIds);
         return stacks.stream().map(stack -> new UserStack(user, stack)).toList();
     }

--- a/src/main/java/dev/steady/user/service/UserService.java
+++ b/src/main/java/dev/steady/user/service/UserService.java
@@ -38,6 +38,10 @@ public class UserService {
         return savedUser.getId();
     }
 
+    public Boolean existsByNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+
     private List<Stack> getStacks(List<Long> stackIds) {
         return stackIds.stream()
                 .map(stackId -> stackRepository.findById(stackId).orElseThrow(IllegalArgumentException::new))

--- a/src/main/java/dev/steady/user/service/UserService.java
+++ b/src/main/java/dev/steady/user/service/UserService.java
@@ -8,7 +8,7 @@ import dev.steady.user.domain.repository.PositionRepository;
 import dev.steady.user.domain.repository.StackRepository;
 import dev.steady.user.domain.repository.UserRepository;
 import dev.steady.user.domain.repository.UserStackRepository;
-import dev.steady.user.dto.request.CreateUserRequest;
+import dev.steady.user.dto.request.UserCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +26,7 @@ public class UserService {
     private final UserStackRepository userStackRepository;
 
     @Transactional
-    public Long createUser(CreateUserRequest request) {
+    public Long createUser(UserCreateRequest request) {
         Position position = getPosition(request.positionId());
 
         User user = request.toEntity(position);

--- a/src/test/java/dev/steady/auth/service/AccountServiceTest.java
+++ b/src/test/java/dev/steady/auth/service/AccountServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import static dev.steady.auth.service.Fixtures.AccountFixture.createAccount;
 import static dev.steady.user.fixture.UserFixtures.createUser;
@@ -29,6 +30,9 @@ class AccountServiceTest {
 
     @Autowired
     private PositionRepository positionRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
 
     @AfterEach
     void tearDown() {
@@ -52,11 +56,15 @@ class AccountServiceTest {
 
         // when
         accountService.registerUser(savedAccount.getId(), savedUser.getId());
+        var foundAccount = transactionTemplate.execute(status -> {
+                    return accountRepository.findById(savedAccount.getId()).get();
+                }
+        );
 
         // then
         assertAll(
-                () -> assertThat(savedAccount).isNotNull(),
-                () -> assertThat(savedAccount.getId()).isEqualTo(savedUser.getId())
+                () -> assertThat(foundAccount.getUser()).isNotNull(),
+                () -> assertThat(foundAccount.getUser().getId()).isEqualTo(savedUser.getId())
         );
     }
 

--- a/src/test/java/dev/steady/auth/service/AccountServiceTest.java
+++ b/src/test/java/dev/steady/auth/service/AccountServiceTest.java
@@ -1,0 +1,42 @@
+package dev.steady.auth.service;
+
+import dev.steady.auth.domain.repository.AccountRepository;
+import dev.steady.auth.service.Fixtures.AccountFixture;
+import dev.steady.user.domain.repository.UserRepository;
+import dev.steady.user.fixture.UserFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+class AccountServiceTest {
+
+    @Autowired
+    private AccountService accountService;
+    @Autowired
+    private AccountRepository accountRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("Account에 user를 등록할 수 있다.")
+    void registerUser() {
+        // given
+        var account = AccountFixture.createAccount();
+        var user = UserFixtures.createUser(UserFixtures.createPosition());
+
+        var savedAccount = accountRepository.save(account);
+        var savedUser = userRepository.save(user);
+        
+        // when
+        accountService.registerUser(savedAccount.getId(), savedUser.getId());
+
+        // then
+        assertThat(account.getUser().getId()).isEqualTo(savedUser.getId());
+    }
+}

--- a/src/test/java/dev/steady/auth/service/AccountServiceTest.java
+++ b/src/test/java/dev/steady/auth/service/AccountServiceTest.java
@@ -1,42 +1,63 @@
 package dev.steady.auth.service;
 
 import dev.steady.auth.domain.repository.AccountRepository;
-import dev.steady.auth.service.Fixtures.AccountFixture;
+import dev.steady.user.domain.repository.PositionRepository;
 import dev.steady.user.domain.repository.UserRepository;
 import dev.steady.user.fixture.UserFixtures;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
+import static dev.steady.auth.service.Fixtures.AccountFixture.createAccount;
+import static dev.steady.user.fixture.UserFixtures.createUser;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
-@Transactional
 @SpringBootTest
 class AccountServiceTest {
 
     @Autowired
     private AccountService accountService;
+
     @Autowired
     private AccountRepository accountRepository;
+
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private PositionRepository positionRepository;
+
+    @AfterEach
+    void tearDown() {
+        accountRepository.deleteAll();
+        userRepository.deleteAll();
+        positionRepository.deleteAll();
+    }
+
     @Test
-    @DisplayName("Account에 user를 등록할 수 있다.")
+    @DisplayName("Account가 존재한다면 User를 등록할 수 있다.")
     void registerUser() {
         // given
-        var account = AccountFixture.createAccount();
-        var user = UserFixtures.createUser(UserFixtures.createPosition());
-
+        var account = createAccount();
         var savedAccount = accountRepository.save(account);
+
+        var position = UserFixtures.createPosition();
+        var savedPosition = positionRepository.save(position);
+
+        var user = createUser(savedPosition);
         var savedUser = userRepository.save(user);
-        
+
         // when
         accountService.registerUser(savedAccount.getId(), savedUser.getId());
 
         // then
-        assertThat(account.getUser().getId()).isEqualTo(savedUser.getId());
+        assertAll(
+                () -> assertThat(savedAccount).isNotNull(),
+                () -> assertThat(savedAccount.getId()).isEqualTo(savedUser.getId())
+        );
     }
+
 }

--- a/src/test/java/dev/steady/auth/service/Fixtures/AccountFixture.java
+++ b/src/test/java/dev/steady/auth/service/Fixtures/AccountFixture.java
@@ -4,7 +4,9 @@ import dev.steady.auth.domain.Account;
 import dev.steady.auth.domain.Platform;
 
 public class AccountFixture {
+    
     public static Account createAccount() {
         return new Account(Platform.KAKAO, "111111");
     }
+
 }

--- a/src/test/java/dev/steady/auth/service/Fixtures/AccountFixture.java
+++ b/src/test/java/dev/steady/auth/service/Fixtures/AccountFixture.java
@@ -1,0 +1,10 @@
+package dev.steady.auth.service.Fixtures;
+
+import dev.steady.auth.domain.Account;
+import dev.steady.auth.domain.Platform;
+
+public class AccountFixture {
+    public static Account createAccount() {
+        return new Account(Platform.KAKAO, "111111");
+    }
+}

--- a/src/test/java/dev/steady/steady/service/SteadyServiceTest.java
+++ b/src/test/java/dev/steady/steady/service/SteadyServiceTest.java
@@ -3,6 +3,7 @@ package dev.steady.steady.service;
 import dev.steady.steady.domain.Participant;
 import dev.steady.steady.domain.Steady;
 import dev.steady.steady.domain.SteadyStack;
+import dev.steady.steady.domain.SteadyStatus;
 import dev.steady.steady.domain.repository.ParticipantRepository;
 import dev.steady.steady.domain.repository.SteadyPositionRepository;
 import dev.steady.steady.domain.repository.SteadyQuestionRepository;

--- a/src/test/java/dev/steady/user/service/UserServiceTest.java
+++ b/src/test/java/dev/steady/user/service/UserServiceTest.java
@@ -1,0 +1,62 @@
+package dev.steady.user.service;
+
+import dev.steady.user.domain.Stack;
+import dev.steady.user.domain.repository.PositionRepository;
+import dev.steady.user.domain.repository.StackRepository;
+import dev.steady.user.domain.repository.UserRepository;
+import dev.steady.user.domain.repository.UserStackRepository;
+import dev.steady.user.dto.request.CreateUserRequest;
+import dev.steady.user.fixture.UserFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Transactional
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private StackRepository stackRepository;
+    @Autowired
+    private PositionRepository positionRepository;
+    @Autowired
+    private UserStackRepository userStackRepository;
+
+    @DisplayName("프로필 정보를 입력받아 유저를 생성한다.")
+    @Test
+    void createUser() {
+        // given
+        var savedPosition = positionRepository.save(UserFixtures.createPosition());
+        var savedStacks = stackRepository.saveAll(
+                IntStream.range(0, 3)
+                        .mapToObj(i -> UserFixtures.createStack())
+                        .toList());
+        var stackIds = savedStacks.stream().map(Stack::getId).toList();
+
+        // when
+        var request = new CreateUserRequest(1L, "Nickname", savedPosition.getId(), stackIds);
+        var userId = userService.createUser(request);
+
+        var userStacks = userStackRepository.findAllByUserId(userId);
+
+        // then
+        var user = userRepository.findById(userId).get();
+        assertAll(
+                () -> assertThat(user.getId()).isEqualTo(userId),
+                () -> assertThat(user.getPosition()).isEqualTo(savedPosition),
+                () -> assertThat(userStacks).hasSameSizeAs(request.stackIds())
+        );
+    }
+
+}

--- a/src/test/java/dev/steady/user/service/UserServiceTest.java
+++ b/src/test/java/dev/steady/user/service/UserServiceTest.java
@@ -33,7 +33,7 @@ class UserServiceTest {
     @Autowired
     private UserStackRepository userStackRepository;
 
-    @DisplayName("프로필 정보를 입력받아 유저를 생성한다.")
+    @DisplayName("프로필 정보를 입력 받아 유저를 생성한다.")
     @Test
     void createUser() {
         // given

--- a/src/test/java/dev/steady/user/service/UserServiceTest.java
+++ b/src/test/java/dev/steady/user/service/UserServiceTest.java
@@ -1,47 +1,64 @@
 package dev.steady.user.service;
 
 import dev.steady.user.domain.Stack;
+import dev.steady.user.domain.User;
 import dev.steady.user.domain.repository.PositionRepository;
 import dev.steady.user.domain.repository.StackRepository;
 import dev.steady.user.domain.repository.UserRepository;
 import dev.steady.user.domain.repository.UserStackRepository;
 import dev.steady.user.dto.request.UserCreateRequest;
-import dev.steady.user.fixture.UserFixtures;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.stream.IntStream;
 
+import static dev.steady.user.fixture.UserFixtures.createPosition;
+import static dev.steady.user.fixture.UserFixtures.createStack;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-@Transactional
 @SpringBootTest
 class UserServiceTest {
 
     @Autowired
     private UserService userService;
+
     @Autowired
     private UserRepository userRepository;
+
     @Autowired
     private StackRepository stackRepository;
+
     @Autowired
     private PositionRepository positionRepository;
+
     @Autowired
     private UserStackRepository userStackRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @AfterEach
+    void tearDown() {
+        userStackRepository.deleteAll();
+        userRepository.deleteAll();
+        positionRepository.deleteAll();
+        stackRepository.deleteAll();
+    }
 
     @DisplayName("프로필 정보를 입력 받아 유저를 생성한다.")
     @Test
     void createUser() {
         // given
-        var savedPosition = positionRepository.save(UserFixtures.createPosition());
-        var savedStacks = stackRepository.saveAll(
-                IntStream.range(0, 3)
-                        .mapToObj(i -> UserFixtures.createStack())
-                        .toList());
+        var savedPosition = positionRepository.save(createPosition());
+        var stacks = IntStream.range(0, 3)
+                .mapToObj(i -> createStack())
+                .toList();
+        var savedStacks = stackRepository.saveAll(stacks);
         var stackIds = savedStacks.stream().map(Stack::getId).toList();
 
         // when
@@ -50,8 +67,13 @@ class UserServiceTest {
 
         var userStacks = userStackRepository.findAllByUserId(userId);
 
-        // then
-        var user = userRepository.findById(userId).get();
+
+        User user = transactionTemplate.execute(status -> {
+            var foundUser = userRepository.findById(userId).get();
+            foundUser.getPosition().getName();
+            return foundUser;
+        });
+
         assertAll(
                 () -> assertThat(user.getId()).isEqualTo(userId),
                 () -> assertThat(user.getPosition()).isEqualTo(savedPosition),

--- a/src/test/java/dev/steady/user/service/UserServiceTest.java
+++ b/src/test/java/dev/steady/user/service/UserServiceTest.java
@@ -76,7 +76,7 @@ class UserServiceTest {
 
         assertAll(
                 () -> assertThat(user.getId()).isEqualTo(userId),
-                () -> assertThat(user.getPosition()).isEqualTo(savedPosition),
+                () -> assertThat(user.getPosition().getName()).isEqualTo(savedPosition.getName()),
                 () -> assertThat(userStacks).hasSameSizeAs(request.stackIds())
         );
     }

--- a/src/test/java/dev/steady/user/service/UserServiceTest.java
+++ b/src/test/java/dev/steady/user/service/UserServiceTest.java
@@ -5,7 +5,7 @@ import dev.steady.user.domain.repository.PositionRepository;
 import dev.steady.user.domain.repository.StackRepository;
 import dev.steady.user.domain.repository.UserRepository;
 import dev.steady.user.domain.repository.UserStackRepository;
-import dev.steady.user.dto.request.CreateUserRequest;
+import dev.steady.user.dto.request.UserCreateRequest;
 import dev.steady.user.fixture.UserFixtures;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,7 +45,7 @@ class UserServiceTest {
         var stackIds = savedStacks.stream().map(Stack::getId).toList();
 
         // when
-        var request = new CreateUserRequest(1L, "Nickname", savedPosition.getId(), stackIds);
+        var request = new UserCreateRequest(1L, "Nickname", savedPosition.getId(), stackIds);
         var userId = userService.createUser(request);
 
         var userStacks = userStackRepository.findAllByUserId(userId);


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] **테스트**
- [ ] **문서화 작업**
## 💡 어떤 작업을 하셨나요?
**Issue Number** : close #10 

**작업 내용**
- [x] `nickname`, `positionId`, `stackIds` 값을 받아 User 생성하는 로직 구현
- [x] 생성된 User를 `accountId`에 해당하는 `Account` 엔티티에 등록하는 로직 구현
- [x] 닉네임 중복 검사 API 구현
  
## 📝리뷰어에게
- `User` 클래스 안에 `DEFAULT_PROFILE_IMAGE_URL`을 상수로 두고 `User`를 생성할 때 생성자에서  `profileImage` 필드에 값을 넣어주는 식으로 구현했는데 이 부분이 괜찮은지 조언 부탁드립니다.
- `User`를 생성하는 기능 api 엔드포인트를 `api/v1/user/profile`로 두고, 이때 생성되는 `User`와 연결할 `Account`의 id는 Request Body로 받도록 했는데 다른 분의 의견이 궁금합니다. 개인적으로는 엔드포인트가 user라서 `path variable`로 `accountId`를 받는 게 적절하지 않다고 생각했습니다..! _아래처럼 요청을 받는다고 보시면 됩니다!_
  ```Json
  {
      "accountId": 1,
	  "nickname": "닉네임",
	  "position": 1,
	  "stack": [1, 2]    // 기술스택의 id
  }
  ```