### PR TITLE
[3차 스프린트 - Review] 피어 리뷰 기능 구현

### DIFF
--- a/src/main/java/dev/steady/review/controller/ReviewController.java
+++ b/src/main/java/dev/steady/review/controller/ReviewController.java
@@ -1,0 +1,36 @@
+package dev.steady.review.controller;
+
+import dev.steady.global.auth.Auth;
+import dev.steady.global.auth.UserInfo;
+import dev.steady.review.dto.ReviewCreateRequest;
+import dev.steady.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @PostMapping("steadies/{steadyId}/review")
+    public ResponseEntity<Void> createReview(@PathVariable Long steadyId,
+                                             @RequestBody ReviewCreateRequest request,
+                                             @Auth UserInfo userInfo) {
+        Long reviewId = reviewService.createReview(steadyId, request, userInfo);
+        reviewService.createUserCards(request);
+
+        return ResponseEntity.created(
+                        URI.create(String.format("/api/v1/steadies/%d/review/%d", steadyId, reviewId)))
+                .build();
+    }
+
+}

--- a/src/main/java/dev/steady/review/domain/Card.java
+++ b/src/main/java/dev/steady/review/domain/Card.java
@@ -14,9 +14,9 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "stcikers")
+@Table(name = "cards")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Sticker {
+public class Card {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,7 +26,7 @@ public class Sticker {
     private String content;
 
     @Builder
-    private Sticker(String content) {
+    public Card(String content) {
         this.content = content;
     }
 

--- a/src/main/java/dev/steady/review/domain/Card.java
+++ b/src/main/java/dev/steady/review/domain/Card.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,7 +24,6 @@ public class Card {
     @Column(nullable = false)
     private String content;
 
-    @Builder
     public Card(String content) {
         this.content = content;
     }

--- a/src/main/java/dev/steady/review/domain/Review.java
+++ b/src/main/java/dev/steady/review/domain/Review.java
@@ -1,7 +1,7 @@
 package dev.steady.review.domain;
 
+import dev.steady.steady.domain.Participant;
 import dev.steady.steady.domain.Steady;
-import dev.steady.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -28,11 +28,11 @@ public class Review {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reviewer_id")
-    private User reviewer;
+    private Participant reviewer;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reviewee_id")
-    private User reviewee;
+    private Participant reviewee;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Steady steady;
@@ -44,16 +44,15 @@ public class Review {
     private boolean isPublic;
 
     @Builder
-    private Review(User reviewer,
-                   User reviewee,
+    private Review(Participant reviewer,
+                   Participant reviewee,
                    Steady steady,
-                   String comment,
-                   boolean isPublic) {
+                   String comment) {
         this.reviewer = reviewer;
         this.reviewee = reviewee;
         this.steady = steady;
         this.comment = comment;
-        this.isPublic = isPublic;
+        this.isPublic = true;
     }
 
 }

--- a/src/main/java/dev/steady/review/domain/UserCard.java
+++ b/src/main/java/dev/steady/review/domain/UserCard.java
@@ -1,5 +1,6 @@
 package dev.steady.review.domain;
 
+import dev.steady.user.domain.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -14,24 +15,24 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "review_stickers")
+@Table(name = "user_cards")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ReviewSticker {
+public class UserCard {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Review review;
+    private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Sticker sticker;
+    private Card card;
 
     @Builder
-    private ReviewSticker(Review review, Sticker sticker) {
-        this.review = review;
-        this.sticker = sticker;
+    public UserCard(User user, Card card) {
+        this.user = user;
+        this.card = card;
     }
 
 }

--- a/src/main/java/dev/steady/review/domain/repository/CardRepository.java
+++ b/src/main/java/dev/steady/review/domain/repository/CardRepository.java
@@ -1,0 +1,16 @@
+package dev.steady.review.domain.repository;
+
+import dev.steady.global.exception.NotFoundException;
+import dev.steady.review.domain.Card;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import static dev.steady.review.exception.ReviewErrorCode.CARD_NOT_FOUND;
+
+public interface CardRepository extends JpaRepository<Card, Long> {
+
+    default Card getById(Long cardId) {
+        return findById(cardId)
+                .orElseThrow(() -> new NotFoundException(CARD_NOT_FOUND));
+    }
+    
+}

--- a/src/main/java/dev/steady/review/domain/repository/CardRepository.java
+++ b/src/main/java/dev/steady/review/domain/repository/CardRepository.java
@@ -12,5 +12,5 @@ public interface CardRepository extends JpaRepository<Card, Long> {
         return findById(cardId)
                 .orElseThrow(() -> new NotFoundException(CARD_NOT_FOUND));
     }
-    
+
 }

--- a/src/main/java/dev/steady/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/dev/steady/review/domain/repository/ReviewRepository.java
@@ -1,7 +1,10 @@
 package dev.steady.review.domain.repository;
 
 import dev.steady.review.domain.Review;
+import dev.steady.steady.domain.Participant;
+import dev.steady.steady.domain.Steady;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    boolean existsByReviewerAndRevieweeAndSteady(Participant reviewer, Participant reviewee, Steady steady);
 }

--- a/src/main/java/dev/steady/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/dev/steady/review/domain/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package dev.steady.review.domain.repository;
+
+import dev.steady.review.domain.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/dev/steady/review/domain/repository/UserCardRepository.java
+++ b/src/main/java/dev/steady/review/domain/repository/UserCardRepository.java
@@ -1,7 +1,12 @@
 package dev.steady.review.domain.repository;
 
 import dev.steady.review.domain.UserCard;
+import dev.steady.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserCardRepository extends JpaRepository<UserCard, Long> {
+    List<UserCard> findAllByUser(User user);
+    
 }

--- a/src/main/java/dev/steady/review/domain/repository/UserCardRepository.java
+++ b/src/main/java/dev/steady/review/domain/repository/UserCardRepository.java
@@ -1,0 +1,7 @@
+package dev.steady.review.domain.repository;
+
+import dev.steady.review.domain.UserCard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserCardRepository extends JpaRepository<UserCard, Long> {
+}

--- a/src/main/java/dev/steady/review/dto/ReviewCreateRequest.java
+++ b/src/main/java/dev/steady/review/dto/ReviewCreateRequest.java
@@ -1,0 +1,25 @@
+package dev.steady.review.dto;
+
+import dev.steady.review.domain.Review;
+import dev.steady.steady.domain.Participant;
+import dev.steady.steady.domain.Steady;
+
+import java.util.List;
+
+public record ReviewCreateRequest(
+        Long reviewerId,
+        Long revieweeId,
+        List<Long> cardIds,
+        String comment
+) {
+
+    public Review toEntity(Participant reviewer, Participant reviewee, Steady steady) {
+        return Review.builder()
+                .steady(steady)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .comment(comment)
+                .build();
+    }
+
+}

--- a/src/main/java/dev/steady/review/dto/ReviewCreateRequest.java
+++ b/src/main/java/dev/steady/review/dto/ReviewCreateRequest.java
@@ -7,7 +7,6 @@ import dev.steady.steady.domain.Steady;
 import java.util.List;
 
 public record ReviewCreateRequest(
-        Long reviewerId,
         Long revieweeId,
         List<Long> cardIds,
         String comment

--- a/src/main/java/dev/steady/review/exception/InvalidStateException.java
+++ b/src/main/java/dev/steady/review/exception/InvalidStateException.java
@@ -1,0 +1,14 @@
+package dev.steady.review.exception;
+
+import dev.steady.global.exception.BusinessException;
+import dev.steady.global.exception.ErrorCode;
+
+public class InvalidStateException extends BusinessException {
+
+    private final ErrorCode errorCode;
+
+    public InvalidStateException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/dev/steady/review/exception/ReviewErrorCode.java
+++ b/src/main/java/dev/steady/review/exception/ReviewErrorCode.java
@@ -1,0 +1,29 @@
+package dev.steady.review.exception;
+
+import dev.steady.global.exception.ErrorCode;
+
+public enum ReviewErrorCode implements ErrorCode {
+
+    CARD_NOT_FOUND("R001", "카드를 찾을 수 없습니다."),
+    STEADY_NOT_FINISHED("R002", "스테디가 종료되지 않았습니다."),
+    REVIEWER_ID_MISMATCH("R003", "사용자 ID가 리뷰어 ID와 일치하지 않습니다."),
+    REVIEWEE_EQUALS_REVIEWER("R004", "리뷰이와 리뷰어가 동일합니다.");
+
+    private final String code;
+    private final String message;
+
+    ReviewErrorCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/dev/steady/review/exception/ReviewErrorCode.java
+++ b/src/main/java/dev/steady/review/exception/ReviewErrorCode.java
@@ -6,8 +6,8 @@ public enum ReviewErrorCode implements ErrorCode {
 
     CARD_NOT_FOUND("R001", "카드를 찾을 수 없습니다."),
     STEADY_NOT_FINISHED("R002", "스테디가 종료되지 않았습니다."),
-    REVIEWER_ID_MISMATCH("R003", "사용자 ID가 리뷰어 ID와 일치하지 않습니다."),
-    REVIEWEE_EQUALS_REVIEWER("R004", "리뷰이와 리뷰어가 동일합니다.");
+    REVIEWEE_EQUALS_REVIEWER("R003", "리뷰이와 리뷰어가 동일합니다."),
+    REVIEW_DUPLICATE("R004", "리뷰를 중복 제출할 수 없습니다.");
 
     private final String code;
     private final String message;
@@ -26,4 +26,5 @@ public enum ReviewErrorCode implements ErrorCode {
     public String message() {
         return message;
     }
+
 }

--- a/src/main/java/dev/steady/review/service/ReviewService.java
+++ b/src/main/java/dev/steady/review/service/ReviewService.java
@@ -1,7 +1,6 @@
 package dev.steady.review.service;
 
 import dev.steady.global.auth.UserInfo;
-import dev.steady.global.exception.ForbiddenException;
 import dev.steady.review.domain.Card;
 import dev.steady.review.domain.Review;
 import dev.steady.review.domain.UserCard;
@@ -10,8 +9,8 @@ import dev.steady.review.domain.repository.ReviewRepository;
 import dev.steady.review.domain.repository.UserCardRepository;
 import dev.steady.review.dto.ReviewCreateRequest;
 import dev.steady.steady.domain.Participant;
+import dev.steady.steady.domain.Participants;
 import dev.steady.steady.domain.Steady;
-import dev.steady.steady.domain.repository.ParticipantRepository;
 import dev.steady.steady.domain.repository.SteadyRepository;
 import dev.steady.steady.exception.InvalidStateException;
 import dev.steady.user.domain.User;
@@ -24,7 +23,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static dev.steady.review.exception.ReviewErrorCode.REVIEWEE_EQUALS_REVIEWER;
-import static dev.steady.review.exception.ReviewErrorCode.REVIEWER_ID_MISMATCH;
+import static dev.steady.review.exception.ReviewErrorCode.REVIEW_DUPLICATE;
 import static dev.steady.review.exception.ReviewErrorCode.STEADY_NOT_FINISHED;
 
 @Service
@@ -65,7 +64,6 @@ public class ReviewService {
         return savedReview.getId();
     }
 
-
     @Transactional
     public List<UserCard> createUserCards(ReviewCreateRequest request) {
         User reviewee = userRepository.getUserBy(request.revieweeId());
@@ -91,8 +89,12 @@ public class ReviewService {
         return steadyRepository.getSteady(steadyId);
     }
 
-    private Participant getParticipant(Long participantId) {
-        return participantRepository.getById(participantId);
+    private boolean isAlreadyReviewed(Participant reviewer, Participant reviewee, Steady steady) {
+        return reviewRepository.existsByReviewerAndRevieweeAndSteady(
+                reviewer,
+                reviewee,
+                steady
+        );
     }
 
 }

--- a/src/main/java/dev/steady/review/service/ReviewService.java
+++ b/src/main/java/dev/steady/review/service/ReviewService.java
@@ -1,0 +1,72 @@
+package dev.steady.review.service;
+
+import dev.steady.global.auth.UserInfo;
+import dev.steady.global.exception.ForbiddenException;
+import dev.steady.review.domain.Review;
+import dev.steady.review.domain.repository.CardRepository;
+import dev.steady.review.domain.repository.ReviewRepository;
+import dev.steady.review.domain.repository.UserCardRepository;
+import dev.steady.review.dto.ReviewCreateRequest;
+import dev.steady.steady.domain.Participant;
+import dev.steady.steady.domain.Steady;
+import dev.steady.steady.domain.repository.ParticipantRepository;
+import dev.steady.steady.domain.repository.SteadyRepository;
+import dev.steady.steady.exception.InvalidStateException;
+import dev.steady.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+import static dev.steady.review.exception.ReviewErrorCode.REVIEWEE_EQUALS_REVIEWER;
+import static dev.steady.review.exception.ReviewErrorCode.REVIEWER_ID_MISMATCH;
+import static dev.steady.review.exception.ReviewErrorCode.STEADY_NOT_FINISHED;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final SteadyRepository steadyRepository;
+    private final ParticipantRepository participantRepository;
+    private final UserRepository userRepository;
+    private final CardRepository cardRepository;
+    private final UserCardRepository userCardRepository;
+
+    @Transactional
+    public Long createReview(Long steadyId, ReviewCreateRequest request, UserInfo userInfo) {
+        Long reviewerId = request.reviewerId();
+        Long revieweeId = request.revieweeId();
+        if (Objects.equals(revieweeId, reviewerId)) {
+            throw new InvalidStateException(REVIEWEE_EQUALS_REVIEWER);
+        }
+
+        Long reviewerUserId = getParticipant(reviewerId).getUser().getId();
+        if (!Objects.equals(reviewerUserId, userInfo.userId())) {
+            throw new ForbiddenException(REVIEWER_ID_MISMATCH);
+        }
+
+        Steady steady = getSteady(steadyId);
+        if (!steady.isFinished()) {
+            throw new InvalidStateException(STEADY_NOT_FINISHED);
+        }
+
+        Participant reviewer = getParticipant(reviewerId);
+        Participant reviewee = getParticipant(revieweeId);
+
+        Review review = request.toEntity(reviewer, reviewee, steady);
+        Review savedReview = reviewRepository.save(review);
+
+        return savedReview.getId();
+    }
+
+    private Steady getSteady(Long steadyId) {
+        return steadyRepository.getSteady(steadyId);
+    }
+
+    private Participant getParticipant(Long participantId) {
+        return participantRepository.getById(participantId);
+    }
+
+}

--- a/src/main/java/dev/steady/review/service/ReviewService.java
+++ b/src/main/java/dev/steady/review/service/ReviewService.java
@@ -1,6 +1,7 @@
 package dev.steady.review.service;
 
 import dev.steady.global.auth.UserInfo;
+import dev.steady.global.exception.InvalidStateException;
 import dev.steady.review.domain.Card;
 import dev.steady.review.domain.Review;
 import dev.steady.review.domain.UserCard;
@@ -12,7 +13,6 @@ import dev.steady.steady.domain.Participant;
 import dev.steady.steady.domain.Participants;
 import dev.steady.steady.domain.Steady;
 import dev.steady.steady.domain.repository.SteadyRepository;
-import dev.steady.steady.exception.InvalidStateException;
 import dev.steady.user.domain.User;
 import dev.steady.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/dev/steady/review/service/ReviewService.java
+++ b/src/main/java/dev/steady/review/service/ReviewService.java
@@ -65,14 +65,14 @@ public class ReviewService {
     }
 
     @Transactional
-    public List<UserCard> createUserCards(ReviewCreateRequest request) {
+    public void createUserCards(ReviewCreateRequest request) {
         User reviewee = userRepository.getUserBy(request.revieweeId());
         List<Card> cards = getCards(request.cardIds());
         List<UserCard> userCards = cards.stream()
                 .map(card -> new UserCard(reviewee, card))
                 .toList();
 
-        return userCardRepository.saveAll(userCards);
+        userCardRepository.saveAll(userCards);
     }
 
     private List<Card> getCards(List<Long> cardIds) {

--- a/src/main/java/dev/steady/review/service/ReviewService.java
+++ b/src/main/java/dev/steady/review/service/ReviewService.java
@@ -2,7 +2,9 @@ package dev.steady.review.service;
 
 import dev.steady.global.auth.UserInfo;
 import dev.steady.global.exception.ForbiddenException;
+import dev.steady.review.domain.Card;
 import dev.steady.review.domain.Review;
+import dev.steady.review.domain.UserCard;
 import dev.steady.review.domain.repository.CardRepository;
 import dev.steady.review.domain.repository.ReviewRepository;
 import dev.steady.review.domain.repository.UserCardRepository;
@@ -12,11 +14,13 @@ import dev.steady.steady.domain.Steady;
 import dev.steady.steady.domain.repository.ParticipantRepository;
 import dev.steady.steady.domain.repository.SteadyRepository;
 import dev.steady.steady.exception.InvalidStateException;
+import dev.steady.user.domain.User;
 import dev.steady.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Objects;
 
 import static dev.steady.review.exception.ReviewErrorCode.REVIEWEE_EQUALS_REVIEWER;
@@ -59,6 +63,28 @@ public class ReviewService {
         Review savedReview = reviewRepository.save(review);
 
         return savedReview.getId();
+    }
+
+
+    @Transactional
+    public List<UserCard> createUserCards(ReviewCreateRequest request) {
+        User reviewee = getParticipant(request.revieweeId()).getUser();
+        List<Card> cards = getCards(request.cardIds());
+        List<UserCard> userCards = cards.stream()
+                .map(card -> new UserCard(reviewee, card))
+                .toList();
+
+        return userCardRepository.saveAll(userCards);
+    }
+
+    private List<Card> getCards(List<Long> cardIds) {
+        return cardIds.stream()
+                .map(this::getCard)
+                .toList();
+    }
+
+    private Card getCard(Long cardId) {
+        return cardRepository.getById(cardId);
     }
 
     private Steady getSteady(Long steadyId) {

--- a/src/main/java/dev/steady/steady/domain/Participant.java
+++ b/src/main/java/dev/steady/steady/domain/Participant.java
@@ -34,7 +34,7 @@ public class Participant extends BaseEntity {
     @Column(name = "is_leader", nullable = false)
     private boolean isLeader;
 
-    private Participant(User user, Steady steady, boolean isLeader) {
+    public Participant(User user, Steady steady, boolean isLeader) {
         this.user = user;
         this.steady = steady;
         this.isLeader = isLeader;

--- a/src/main/java/dev/steady/steady/domain/Participant.java
+++ b/src/main/java/dev/steady/steady/domain/Participant.java
@@ -48,4 +48,8 @@ public class Participant extends BaseEntity {
         return new Participant(user, steady, false);
     }
 
+    public Long getUserId() {
+        return this.user.getId();
+    }
+
 }

--- a/src/main/java/dev/steady/steady/domain/Participants.java
+++ b/src/main/java/dev/steady/steady/domain/Participants.java
@@ -37,7 +37,7 @@ public class Participants {
         return steadyParticipants.stream()
                 .filter(Participant::isLeader)
                 .findFirst()
-                .orElseThrow(IllegalArgumentException::new)
+                .orElseThrow(() -> new NotFoundException(PARTICIPANT_NOT_FOUND))
                 .getUser();
     }
 

--- a/src/main/java/dev/steady/steady/domain/Participants.java
+++ b/src/main/java/dev/steady/steady/domain/Participants.java
@@ -1,6 +1,7 @@
 package dev.steady.steady.domain;
 
 import dev.steady.global.exception.InvalidStateException;
+import dev.steady.global.exception.NotFoundException;
 import dev.steady.user.domain.User;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
@@ -10,7 +11,9 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+import static dev.steady.steady.exception.ParticipantErrorCode.PARTICIPANT_NOT_FOUND;
 import static dev.steady.steady.exception.SteadyErrorCode.PARTICIPANT_LIMIT_EXCEEDED;
 
 @Embeddable
@@ -36,6 +39,13 @@ public class Participants {
                 .findFirst()
                 .orElseThrow(IllegalArgumentException::new)
                 .getUser();
+    }
+
+    public Participant getParticipantByUserId(Long userId) {
+        return steadyParticipants.stream()
+                .filter(participant -> Objects.equals(participant.getUserId(), userId))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException(PARTICIPANT_NOT_FOUND));
     }
 
     public List<Participant> getAllParticipants() {

--- a/src/main/java/dev/steady/steady/domain/Steady.java
+++ b/src/main/java/dev/steady/steady/domain/Steady.java
@@ -177,6 +177,10 @@ public class Steady extends BaseEntity {
         return participants.getLeader();
     }
 
+    public boolean isFinished() {
+        return this.status == SteadyStatus.FINISHED;
+    }
+
     private Participants createParticipants(User user) {
         Participants participants = new Participants(participantLimit);
         participants.add(Participant.createLeader(user, this));

--- a/src/main/java/dev/steady/steady/domain/repository/ParticipantRepository.java
+++ b/src/main/java/dev/steady/steady/domain/repository/ParticipantRepository.java
@@ -1,12 +1,20 @@
 package dev.steady.steady.domain.repository;
 
+import dev.steady.global.exception.NotFoundException;
 import dev.steady.steady.domain.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
+import static dev.steady.steady.exception.ParticipantErrorCode.PARTICIPANT_NOT_FOUND;
+
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
 
     List<Participant> findBySteadyId(Long id);
+
+    default Participant getById(Long participantId) {
+        return findById(participantId)
+                .orElseThrow(() -> new NotFoundException(PARTICIPANT_NOT_FOUND));
+    }
 
 }

--- a/src/main/java/dev/steady/steady/exception/ParticipantErrorCode.java
+++ b/src/main/java/dev/steady/steady/exception/ParticipantErrorCode.java
@@ -23,5 +23,5 @@ public enum ParticipantErrorCode implements ErrorCode {
     public String message() {
         return message;
     }
-    
+
 }

--- a/src/main/java/dev/steady/steady/exception/ParticipantErrorCode.java
+++ b/src/main/java/dev/steady/steady/exception/ParticipantErrorCode.java
@@ -1,0 +1,27 @@
+package dev.steady.steady.exception;
+
+import dev.steady.global.exception.ErrorCode;
+
+public enum ParticipantErrorCode implements ErrorCode {
+
+    PARTICIPANT_NOT_FOUND("P001", "스테디 참여자를 찾을 수 없습니다.");
+
+    private final String code;
+    private final String message;
+
+    ParticipantErrorCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+    
+}

--- a/src/main/java/dev/steady/user/domain/User.java
+++ b/src/main/java/dev/steady/user/domain/User.java
@@ -43,7 +43,7 @@ public class User extends BaseEntity {
     private Position position;
 
     @Builder
-    public User(String profileImage, String nickname, String bio, Position position) {
+    private User(String profileImage, String nickname, String bio, Position position) {
         this.profileImage = profileImage;
         this.nickname = nickname;
         this.bio = bio;

--- a/src/test/java/dev/steady/application/domain/repository/ApplicationRepositoryTest.java
+++ b/src/test/java/dev/steady/application/domain/repository/ApplicationRepositoryTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import static dev.steady.application.domain.ApplicationStatus.WAITING;
 import static dev.steady.application.fixture.ApplicationFixture.createApplication;
-import static dev.steady.steady.fixture.SteadyFixtures.creatSteady;
+import static dev.steady.steady.fixture.SteadyFixtures.createSteady;
 import static dev.steady.user.fixture.UserFixtures.createFirstUser;
 import static dev.steady.user.fixture.UserFixtures.createPosition;
 import static dev.steady.user.fixture.UserFixtures.createSecondUser;
@@ -64,7 +64,7 @@ class ApplicationRepositoryTest {
         var position = positionRepository.save(createPosition());
         var leader = userRepository.save(createFirstUser(position));
         var savedStack = stackRepository.save(createStack());
-        var steady = steadyRepository.save(creatSteady(leader, savedStack));
+        var steady = steadyRepository.save(createSteady(leader, savedStack));
         var secondUser = userRepository.save(createSecondUser(position));
         var thirdUser = userRepository.save(createThirdUser(position));
         applicationRepository.saveAll(List.of(createApplication(secondUser, steady),

--- a/src/test/java/dev/steady/application/service/ApplicationServiceTest.java
+++ b/src/test/java/dev/steady/application/service/ApplicationServiceTest.java
@@ -32,7 +32,7 @@ import static dev.steady.application.domain.ApplicationStatus.REJECTED;
 import static dev.steady.application.fixture.ApplicationFixture.createApplication;
 import static dev.steady.application.fixture.SurveyResultFixture.createSurveyResultRequests;
 import static dev.steady.global.auth.AuthFixture.createUserInfo;
-import static dev.steady.steady.fixture.SteadyFixtures.creatSteady;
+import static dev.steady.steady.fixture.SteadyFixtures.createSteady;
 import static dev.steady.user.fixture.UserFixtures.createFirstUser;
 import static dev.steady.user.fixture.UserFixtures.createPosition;
 import static dev.steady.user.fixture.UserFixtures.createSecondUser;
@@ -89,7 +89,7 @@ class ApplicationServiceTest {
     void createApplicationTest() {
         //given
         var user = userRepository.save(createSecondUser(position));
-        var steady = steadyRepository.save(creatSteady(user, stack));
+        var steady = steadyRepository.save(createSteady(user, stack));
         var surveyResultRequests = createSurveyResultRequests();
         var userInfo = createUserInfo(user.getId());
 
@@ -106,7 +106,7 @@ class ApplicationServiceTest {
     @Test
     void getApplicationsTest() {
         //given
-        var steady = steadyRepository.save(creatSteady(leader, stack));
+        var steady = steadyRepository.save(createSteady(leader, stack));
         var secondUser = userRepository.save(createSecondUser(position));
         var thirdUser = userRepository.save(createThirdUser(position));
         applicationRepository.saveAll(List.of(createApplication(secondUser, steady),
@@ -128,7 +128,7 @@ class ApplicationServiceTest {
     @Test
     void getApplicationsFailTest() {
         //given
-        var steady = steadyRepository.save(creatSteady(leader, stack));
+        var steady = steadyRepository.save(createSteady(leader, stack));
         var secondUser = userRepository.save(createSecondUser(position));
         var thirdUser = userRepository.save(createThirdUser(position));
         applicationRepository.save(createApplication(secondUser, steady));
@@ -146,7 +146,7 @@ class ApplicationServiceTest {
     @Test
     void getApplicationDetailTest() {
         //given
-        var steady = steadyRepository.save(creatSteady(leader, stack));
+        var steady = steadyRepository.save(createSteady(leader, stack));
         var secondUser = userRepository.save(createSecondUser(position));
         var application = applicationRepository.save(createApplication(secondUser, steady));
         var userInfo = createUserInfo(leader.getId());
@@ -166,7 +166,7 @@ class ApplicationServiceTest {
     @Test
     void getApplicationDetailFailTest() {
         //given
-        var steady = steadyRepository.save(creatSteady(leader, stack));
+        var steady = steadyRepository.save(createSteady(leader, stack));
         var secondUser = userRepository.save(createSecondUser(position));
         var thirdUser = userRepository.save(createThirdUser(position));
         var application = applicationRepository.save(createApplication(secondUser, steady));
@@ -181,7 +181,7 @@ class ApplicationServiceTest {
     @Test
     void createSurveyResultTest() {
         //given
-        var steady = steadyRepository.save(creatSteady(leader, stack));
+        var steady = steadyRepository.save(createSteady(leader, stack));
         var secondUser = userRepository.save(createSecondUser(position));
         var application = applicationRepository.save(createApplication(secondUser, steady));
         var userInfo = createUserInfo(leader.getId());
@@ -198,7 +198,7 @@ class ApplicationServiceTest {
     @Test
     void createSurveyResultFailTest() {
         //given
-        var steady = steadyRepository.save(creatSteady(leader, stack));
+        var steady = steadyRepository.save(createSteady(leader, stack));
         var secondUser = userRepository.save(createSecondUser(position));
         var entity = createApplication(secondUser, steady);
         ReflectionTestUtils.setField(entity, "status", REJECTED);

--- a/src/test/java/dev/steady/review/fixture/ReviewFixtures.java
+++ b/src/test/java/dev/steady/review/fixture/ReviewFixtures.java
@@ -1,0 +1,25 @@
+package dev.steady.review.fixture;
+
+import dev.steady.review.domain.Card;
+import dev.steady.review.dto.ReviewCreateRequest;
+
+import java.util.List;
+
+public class ReviewFixtures {
+
+    public static ReviewCreateRequest createReviewCreateRequest(Long reviewerId, Long revieweeId, List<Long> cardIds) {
+        return new ReviewCreateRequest(
+                reviewerId,
+                revieweeId,
+                cardIds,
+                "리뷰 한 줄 코멘트"
+        );
+    }
+
+    public static Card createCard() {
+        return new Card(
+                "이 팀원은 출석을 열심히 잘 했어요!"
+        );
+    }
+
+}

--- a/src/test/java/dev/steady/review/fixture/ReviewFixtures.java
+++ b/src/test/java/dev/steady/review/fixture/ReviewFixtures.java
@@ -7,9 +7,8 @@ import java.util.List;
 
 public class ReviewFixtures {
 
-    public static ReviewCreateRequest createReviewCreateRequest(Long reviewerId, Long revieweeId, List<Long> cardIds) {
+    public static ReviewCreateRequest createReviewCreateRequest(Long revieweeId, List<Long> cardIds) {
         return new ReviewCreateRequest(
-                reviewerId,
                 revieweeId,
                 cardIds,
                 "리뷰 한 줄 코멘트"

--- a/src/test/java/dev/steady/review/service/ReviewServiceTest.java
+++ b/src/test/java/dev/steady/review/service/ReviewServiceTest.java
@@ -102,7 +102,7 @@ class ReviewServiceTest {
                 List.of(1L, 2L)
         );
 
-        var reviewId = reviewService.createReview(1L, request, userInfo);
+        var reviewId = reviewService.createReview(steady.getId(), request, userInfo);
 
         Review review = transactionTemplate.execute(status -> {
             var foundReview = reviewRepository.findById(reviewId).get();

--- a/src/test/java/dev/steady/review/service/ReviewServiceTest.java
+++ b/src/test/java/dev/steady/review/service/ReviewServiceTest.java
@@ -1,6 +1,8 @@
 package dev.steady.review.service;
 
+import dev.steady.review.domain.Card;
 import dev.steady.review.domain.Review;
+import dev.steady.review.domain.UserCard;
 import dev.steady.review.domain.repository.CardRepository;
 import dev.steady.review.domain.repository.ReviewRepository;
 import dev.steady.review.domain.repository.UserCardRepository;
@@ -21,8 +23,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static dev.steady.global.auth.AuthFixture.createUserInfo;
+import static dev.steady.review.fixture.ReviewFixtures.createCard;
 import static dev.steady.review.fixture.ReviewFixtures.createReviewCreateRequest;
 import static dev.steady.steady.fixture.SteadyFixtures.createFinishedSteady;
 import static dev.steady.steady.fixture.SteadyFixtures.createParticipant;
@@ -113,6 +117,31 @@ class ReviewServiceTest {
                 () -> assertThat(review.getId()).isEqualTo(reviewId),
                 () -> assertThat(review.getReviewer().getId()).isEqualTo(reviewer.getId()),
                 () -> assertThat(review.getReviewee().getId()).isEqualTo(reviewee.getId())
+        );
+    }
+
+    @DisplayName("사용자의 리뷰 카드를 생성할 수 있다.")
+    @Test
+    void createUserCards() {
+        // given
+        List<Card> cards = IntStream.range(0, 3)
+                .mapToObj(i -> createCard())
+                .toList();
+        cardRepository.saveAll(cards);
+
+        // when
+        List<Long> cardIds = List.of(1L, 2L);
+        var request = createReviewCreateRequest(
+                reviewer.getId(),
+                reviewee.getId(),
+                cardIds
+        );
+
+        List<UserCard> userCards = reviewService.createUserCards(request);
+
+        // then
+        assertAll(
+                () -> assertThat(userCards).hasSameSizeAs(cardIds)
         );
     }
 

--- a/src/test/java/dev/steady/review/service/ReviewServiceTest.java
+++ b/src/test/java/dev/steady/review/service/ReviewServiceTest.java
@@ -134,7 +134,8 @@ class ReviewServiceTest {
                 cardIds
         );
 
-        List<UserCard> userCards = reviewService.createUserCards(request);
+        reviewService.createUserCards(request);
+        List<UserCard> userCards = userCardRepository.findAllByUser(reviewee.getUser());
 
         // then
         assertAll(

--- a/src/test/java/dev/steady/review/service/ReviewServiceTest.java
+++ b/src/test/java/dev/steady/review/service/ReviewServiceTest.java
@@ -68,13 +68,14 @@ class ReviewServiceTest {
         var position = positionRepository.save(createPosition());
         var stack = stackRepository.save(createStack());
 
-        var firstUser = userRepository.save(UserFixtures.createFirstUser(position));
-        var secoundUser = userRepository.save(UserFixtures.createSecondUser(position));
+        var leaderUser = userRepository.save(UserFixtures.createFirstUser(position));
+        var reviewerUser = userRepository.save(UserFixtures.createSecondUser(position));
+        var revieweeUser = userRepository.save(UserFixtures.createThirdUser(position));
 
-        this.steady = steadyRepository.save(createFinishedSteady(firstUser, stack));
+        this.steady = steadyRepository.save(createFinishedSteady(leaderUser, stack));
 
-        this.reviewer = participantRepository.save(createParticipant(firstUser, steady));
-        this.reviewee = participantRepository.save(createParticipant(secoundUser, steady));
+        this.reviewer = participantRepository.save(createParticipant(reviewerUser, steady));
+        this.reviewee = participantRepository.save(createParticipant(revieweeUser, steady));
     }
 
     @AfterEach
@@ -93,20 +94,17 @@ class ReviewServiceTest {
     @Test
     void createReview() {
         // given
-        var userInfo = createUserInfo(reviewer.getUser().getId());
+        var userInfo = createUserInfo(reviewer.getUserId());
 
         // when
         var request = createReviewCreateRequest(
-                reviewer.getId(),
-                reviewee.getId(),
+                reviewee.getUserId(),
                 List.of(1L, 2L)
         );
 
         var reviewId = reviewService.createReview(steady.getId(), request, userInfo);
-
         Review review = transactionTemplate.execute(status -> {
             var foundReview = reviewRepository.findById(reviewId).get();
-            foundReview.getId();
             foundReview.getReviewer();
             foundReview.getReviewee();
             return foundReview;
@@ -132,8 +130,7 @@ class ReviewServiceTest {
         // when
         List<Long> cardIds = List.of(1L, 2L);
         var request = createReviewCreateRequest(
-                reviewer.getId(),
-                reviewee.getId(),
+                reviewee.getUserId(),
                 cardIds
         );
 

--- a/src/test/java/dev/steady/review/service/ReviewServiceTest.java
+++ b/src/test/java/dev/steady/review/service/ReviewServiceTest.java
@@ -1,0 +1,119 @@
+package dev.steady.review.service;
+
+import dev.steady.review.domain.Review;
+import dev.steady.review.domain.repository.CardRepository;
+import dev.steady.review.domain.repository.ReviewRepository;
+import dev.steady.review.domain.repository.UserCardRepository;
+import dev.steady.steady.domain.Participant;
+import dev.steady.steady.domain.Steady;
+import dev.steady.steady.domain.repository.ParticipantRepository;
+import dev.steady.steady.domain.repository.SteadyRepository;
+import dev.steady.user.domain.repository.PositionRepository;
+import dev.steady.user.domain.repository.StackRepository;
+import dev.steady.user.domain.repository.UserRepository;
+import dev.steady.user.fixture.UserFixtures;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+
+import static dev.steady.global.auth.AuthFixture.createUserInfo;
+import static dev.steady.review.fixture.ReviewFixtures.createReviewCreateRequest;
+import static dev.steady.steady.fixture.SteadyFixtures.createFinishedSteady;
+import static dev.steady.steady.fixture.SteadyFixtures.createParticipant;
+import static dev.steady.user.fixture.UserFixtures.createPosition;
+import static dev.steady.user.fixture.UserFixtures.createStack;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+class ReviewServiceTest {
+
+    @Autowired
+    private ReviewService reviewService;
+    @Autowired
+    private ReviewRepository reviewRepository;
+    @Autowired
+    private SteadyRepository steadyRepository;
+    @Autowired
+    private ParticipantRepository participantRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CardRepository cardRepository;
+    @Autowired
+    private UserCardRepository userCardRepository;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+    @Autowired
+    private PositionRepository positionRepository;
+    @Autowired
+    private StackRepository stackRepository;
+
+    private Steady steady;
+    private Participant reviewer;
+    private Participant reviewee;
+
+    @BeforeEach
+    void setUp() {
+        var position = positionRepository.save(createPosition());
+        var stack = stackRepository.save(createStack());
+
+        var firstUser = userRepository.save(UserFixtures.createFirstUser(position));
+        var secoundUser = userRepository.save(UserFixtures.createSecondUser(position));
+
+        this.steady = steadyRepository.save(createFinishedSteady(firstUser, stack));
+
+        this.reviewer = participantRepository.save(createParticipant(firstUser, steady));
+        this.reviewee = participantRepository.save(createParticipant(secoundUser, steady));
+    }
+
+    @AfterEach
+    void tearDown() {
+        userCardRepository.deleteAll();
+        reviewRepository.deleteAll();
+        participantRepository.deleteAll();
+        steadyRepository.deleteAll();
+        userRepository.deleteAll();
+        cardRepository.deleteAll();
+        stackRepository.deleteAll();
+        positionRepository.deleteAll();
+    }
+
+    @DisplayName("종료된 스테디에 대하여 리뷰를 생성한다.")
+    @Test
+    void createReview() {
+        // given
+        var userInfo = createUserInfo(reviewer.getUser().getId());
+
+        // when
+        var request = createReviewCreateRequest(
+                reviewer.getId(),
+                reviewee.getId(),
+                List.of(1L, 2L)
+        );
+
+        var reviewId = reviewService.createReview(1L, request, userInfo);
+
+        Review review = transactionTemplate.execute(status -> {
+            var foundReview = reviewRepository.findById(reviewId).get();
+            foundReview.getId();
+            foundReview.getReviewer();
+            foundReview.getReviewee();
+            return foundReview;
+        });
+
+        // then
+        assertAll(
+                () -> assertThat(review.getId()).isEqualTo(reviewId),
+                () -> assertThat(review.getReviewer().getId()).isEqualTo(reviewer.getId()),
+                () -> assertThat(review.getReviewee().getId()).isEqualTo(reviewee.getId())
+        );
+    }
+
+}

--- a/src/test/java/dev/steady/steady/fixture/SteadyFixtures.java
+++ b/src/test/java/dev/steady/steady/fixture/SteadyFixtures.java
@@ -161,4 +161,5 @@ public class SteadyFixtures {
     public static Participant createParticipant(User user, Steady steady) {
         return new Participant(user, steady, false);
     }
+
 }

--- a/src/test/java/dev/steady/steady/fixture/SteadyFixtures.java
+++ b/src/test/java/dev/steady/steady/fixture/SteadyFixtures.java
@@ -102,6 +102,25 @@ public class SteadyFixtures {
                 .build();
     }
 
+    public static Steady createFinishedSteady(User user, Stack stack) {
+        Steady steady = Steady.builder()
+                .name("스테디")
+                .bio("bio")
+                .type(STUDY)
+                .participantLimit(6)
+                .scheduledPeriod(ScheduledPeriod.FIVE_MONTH)
+                .deadline(LocalDate.of(2025, 1, 2))
+                .title("title")
+                .content("content")
+                .user(user)
+                .stacks(List.of(stack))
+                .steadyMode(ONLINE)
+                .build();
+        ReflectionTestUtils.setField(steady, "status", SteadyStatus.FINISHED);
+
+        return steady;
+    }
+
     public static SteadyPosition createSteadyPosition(Steady steady, Position position) {
         return SteadyPosition.builder().steady(steady).position(position).build();
     }

--- a/src/test/java/dev/steady/steady/fixture/SteadyFixtures.java
+++ b/src/test/java/dev/steady/steady/fixture/SteadyFixtures.java
@@ -1,5 +1,6 @@
 package dev.steady.steady.fixture;
 
+import dev.steady.steady.domain.Participant;
 import dev.steady.steady.domain.ScheduledPeriod;
 import dev.steady.steady.domain.Steady;
 import dev.steady.steady.domain.SteadyMode;
@@ -138,4 +139,7 @@ public class SteadyFixtures {
         ));
     }
 
+    public static Participant createParticipant(User user, Steady steady) {
+        return new Participant(user, steady, false);
+    }
 }

--- a/src/test/java/dev/steady/steady/fixture/SteadyFixtures.java
+++ b/src/test/java/dev/steady/steady/fixture/SteadyFixtures.java
@@ -85,7 +85,7 @@ public class SteadyFixtures {
                 .build();
     }
 
-    public static Steady creatSteady(User user, Stack stack) {
+    public static Steady createSteady(User user, Stack stack) {
         return Steady.builder()
                 .name("스테디")
                 .bio("boi")

--- a/src/test/java/dev/steady/steady/service/SteadyServiceTest.java
+++ b/src/test/java/dev/steady/steady/service/SteadyServiceTest.java
@@ -44,8 +44,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static dev.steady.global.auth.AuthFixture.createUserInfo;
-import static dev.steady.steady.fixture.SteadyFixtures.creatSteady;
 import static dev.steady.steady.fixture.SteadyFixtures.createAnotherSteadyRequest;
+import static dev.steady.steady.fixture.SteadyFixtures.createSteady;
 import static dev.steady.steady.fixture.SteadyFixtures.createSteadyRequest;
 import static dev.steady.steady.fixture.SteadyFixtures.createSteadyUpdateRequest;
 import static dev.steady.user.fixture.UserFixtures.createAnotherPosition;
@@ -326,7 +326,7 @@ class SteadyServiceTest {
         var stack = stackRepository.save(createStack());
         var userInfo = new UserInfo(null);
 
-        var steady = steadyRepository.save(creatSteady(leader, stack));
+        var steady = steadyRepository.save(createSteady(leader, stack));
         var steadyId = steady.getId();
         entityManager.flush();
         entityManager.clear();
@@ -370,7 +370,7 @@ class SteadyServiceTest {
         var leader = userRepository.save(createFirstUser(position));
         var stack = stackRepository.save(createStack());
 
-        var steady = steadyRepository.save(creatSteady(leader, stack));
+        var steady = steadyRepository.save(createSteady(leader, stack));
         var steadyId = steady.getId();
 
         var anotherUser = userRepository.save(createSecondUser(position));

--- a/src/test/java/dev/steady/steady/service/SteadyServiceTest.java
+++ b/src/test/java/dev/steady/steady/service/SteadyServiceTest.java
@@ -281,7 +281,7 @@ class SteadyServiceTest {
         var otherUser = userRepository.save(createSecondUser(position));
         var userInfo = createUserInfo(otherUser.getId());
 
-        var steady = steadyRepository.save(creatSteady(leader, stack));
+        var steady = steadyRepository.save(createSteady(leader, stack));
         var steadyId = steady.getId();
         entityManager.flush();
         entityManager.clear();


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] **테스트**
- [ ] **문서화 작업**
## 💡 어떤 작업을 하셨나요?
**Issue Number** : close #83

**작업 내용**
- [x] 기존 엔티티를 ERD 설계에 따라 변경
  - [x] `Sticker` -> `Card`
  - [x] `Review`의 `reviewer`와 `reviewee`를 `Participant`로 변경 
  - [x] 기존에 `Review`에 연결되어 있던 `ReviewCard`를 `User`에 연결되도록 변경
  - [x] 이에 따라 `ReviewCard` -> `UserCard` 클래스명 변경
- [x] 피어 리뷰 기능 구현
## 📝리뷰어에게
- 참여자 조회를 할 때 `userId`를 반환하기 때문에 `userId`와 `steadyId`로 Participant를 조회하려고 했는데, 서비스를 테스트할 때 이 두 값으로 조회하는 것은 unique한 값을 반환하도록 보장되지 않는다는 것을 알게 되었습니다. 그래서 reviewerId와 revieweeId는 `participantId`를 받고, 클라이언트에 로그인한 사용자를 포함한 각 참여자의 `participantId`를 알려주는 API가 필요하다고 생각합니다.
- 리뷰를 남길 수 있는지 검증할 때 `InvalidStateException`을 Review 패키지에 생성했는데, 건희님이 만드신 커스텀 예외랑 동일해서 각각의 패키지에 만들지, 아니면 Global으로 옮길지, 아니면 따로 좋은 Exception 이름이 있을지 의견 부탁드립니다