### PR TITLE
[4차 스프린트 - Steady] QueryDsl 페이징 버그 수정

### DIFF
--- a/src/main/java/dev/steady/steady/infrastructure/SteadySearchRepositoryImpl.java
+++ b/src/main/java/dev/steady/steady/infrastructure/SteadySearchRepositoryImpl.java
@@ -54,12 +54,15 @@ public class SteadySearchRepositoryImpl implements SteadySearchRepository {
                 .distinct()
                 .fetch();
 
-        JPAQuery<Long> count = jpaQueryFactory
-                .select(steady.count())
-                .from(steady)
-                .where(searchCondition(condition));
+        JPAQuery<Steady> count = jpaQueryFactory
+                .selectFrom(steady)
+                .innerJoin(steady.steadyStacks, steadyStack)
+                .innerJoin(steadyPosition)
+                .on(steady.id.eq(steadyPosition.steady.id))
+                .where(searchCondition(condition))
+                .distinct();
         // TODO: 2023-11-04 좋아요 (북마크) 구현된다면 where 조건 추가
-        return PageableExecutionUtils.getPage(steadies, pageable, count::fetchOne);
+        return PageableExecutionUtils.getPage(steadies, pageable, count::fetchCount);
     }
 
     @Override


### PR DESCRIPTION
## ✅ PR 체크리스트
- [ ] **테스트**
- [ ] **문서화 작업**
## 💡 어떤 작업을 하셨나요?
**Issue Number** : close #125 

**작업 내용**
- 페이징 조회 시 `elements` 값들이 실제 결과와 일치하지 않는 문제를 수정하였습니다.
- 실제 조회 쿼리와 페이징을 위한 `count` 쿼리간의 불일치 문제였습니다.(`count` 쿼리에서 `join`을 걸어주지 않았기 때문)
## 📝리뷰어에게
