### PR TITLE
[신청서] 신청서, 질답 양방향 제거 및 대기 상태 신청서 답변 수정 기능 개발

### DIFF
--- a/src/main/java/dev/steady/application/controller/ApplicationController.java
+++ b/src/main/java/dev/steady/application/controller/ApplicationController.java
@@ -2,6 +2,7 @@ package dev.steady.application.controller;
 
 import dev.steady.application.dto.request.ApplicationPageRequest;
 import dev.steady.application.dto.request.ApplicationStatusUpdateRequest;
+import dev.steady.application.dto.request.ApplicationUpdateAnswerRequest;
 import dev.steady.application.dto.request.SurveyResultRequest;
 import dev.steady.application.dto.response.ApplicationDetailResponse;
 import dev.steady.application.dto.response.ApplicationSummaryResponse;
@@ -52,6 +53,14 @@ public class ApplicationController {
                                                                           @Auth UserInfo userInfo) {
         ApplicationDetailResponse applicationDetail = applicationService.getApplicationDetail(applicationId, userInfo);
         return ResponseEntity.ok(applicationDetail);
+    }
+
+    @PatchMapping("/applications/{applicationId}")
+    public ResponseEntity<Void> updateApplicationAnswers(@PathVariable Long applicationId,
+                                                         @RequestBody ApplicationUpdateAnswerRequest request,
+                                                         @Auth UserInfo userInfo) {
+        applicationService.updateApplicationAnswer(applicationId, request, userInfo);
+        return ResponseEntity.noContent().build();
     }
 
     @PatchMapping("/applications/{applicationId}/status")

--- a/src/main/java/dev/steady/application/domain/Application.java
+++ b/src/main/java/dev/steady/application/domain/Application.java
@@ -4,7 +4,6 @@ import dev.steady.global.entity.BaseEntity;
 import dev.steady.global.exception.ForbiddenException;
 import dev.steady.steady.domain.Steady;
 import dev.steady.user.domain.User;
-import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -18,8 +17,6 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 import static dev.steady.application.domain.ApplicationStatus.WAITING;
 import static dev.steady.application.exception.ApplicationErrorCode.APPLICATION_AUTH_FAILURE;
@@ -58,17 +55,21 @@ public class Application extends BaseEntity {
     }
 
     public void updateStatus(ApplicationStatus status, User user) {
-        if (steady.isLeader(user) && this.status == WAITING) {
+        if (steady.isLeader(user) && isWaitingStatus()) {
             this.status = status;
             return;
         }
         throw new ForbiddenException(APPLICATION_AUTH_FAILURE);
     }
 
-    public void validateApplicantOrThrow(User user) {
-        if (!isApplicant(user)) {
+    public void validateUpdateAnswer(User user) {
+        if (!isApplicant(user) || !isWaitingStatus()) {
             throw new ForbiddenException(APPLICATION_AUTH_FAILURE);
         }
+    }
+
+    private boolean isWaitingStatus() {
+        return this.status == WAITING;
     }
 
     private boolean hasAccess(User user) {

--- a/src/main/java/dev/steady/application/domain/SurveyResult.java
+++ b/src/main/java/dev/steady/application/domain/SurveyResult.java
@@ -39,7 +39,6 @@ public class SurveyResult {
                          String question,
                          String answer,
                          int sequence) {
-        application.addSurveyResult(this);
         this.application = application;
         this.question = question;
         this.answer = answer;
@@ -53,8 +52,8 @@ public class SurveyResult {
                 sequence);
     }
 
-    public void setApplication(Application application) {
-        this.application = application;
+    public void updateAnswer(String answer) {
+        this.answer = answer;
     }
 
 }

--- a/src/main/java/dev/steady/application/domain/SurveyResults.java
+++ b/src/main/java/dev/steady/application/domain/SurveyResults.java
@@ -1,26 +1,30 @@
 package dev.steady.application.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.OneToMany;
-import lombok.AccessLevel;
+import dev.steady.global.exception.InvalidValueException;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
 import java.util.List;
 
+import static dev.steady.application.exception.SurveyResultErrorCode.INVALID_SURVEY_SIZE;
+
 @Getter
-@Embeddable
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SurveyResults {
 
-    @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<SurveyResult> values = new ArrayList<>();
+    private final List<SurveyResult> values;
 
-    public void addSurveyResult(SurveyResult surveyResult, Application application) {
-        surveyResult.setApplication(application);
-        values.add(surveyResult);
+    public SurveyResults(List<SurveyResult> values) {
+        this.values = values;
+    }
+
+    public void updateAnswers(List<String> answers) {
+        if (values.size() != answers.size()) {
+            throw new InvalidValueException(INVALID_SURVEY_SIZE);
+        }
+        for (int i = 0; i < values.size(); i++) {
+            SurveyResult surveyResult = values.get(i);
+            String newAnswer = answers.get(i);
+            surveyResult.updateAnswer(newAnswer);
+        }
     }
 
 }

--- a/src/main/java/dev/steady/application/domain/repository/SurveyResultRepository.java
+++ b/src/main/java/dev/steady/application/domain/repository/SurveyResultRepository.java
@@ -1,0 +1,13 @@
+package dev.steady.application.domain.repository;
+
+import dev.steady.application.domain.Application;
+import dev.steady.application.domain.SurveyResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SurveyResultRepository extends JpaRepository<SurveyResult, Long> {
+
+    List<SurveyResult> findByApplicationOrderBySequenceAsc(Application application);
+
+}

--- a/src/main/java/dev/steady/application/dto/request/ApplicationUpdateAnswerRequest.java
+++ b/src/main/java/dev/steady/application/dto/request/ApplicationUpdateAnswerRequest.java
@@ -1,0 +1,6 @@
+package dev.steady.application.dto.request;
+
+import java.util.List;
+
+public record ApplicationUpdateAnswerRequest(List<String> answers) {
+}

--- a/src/main/java/dev/steady/application/dto/response/ApplicationDetailResponse.java
+++ b/src/main/java/dev/steady/application/dto/response/ApplicationDetailResponse.java
@@ -1,14 +1,14 @@
 package dev.steady.application.dto.response;
 
-import dev.steady.application.domain.SurveyResults;
+import dev.steady.application.domain.SurveyResult;
 
 import java.util.List;
 
 public record ApplicationDetailResponse(List<SurveyResultResponse> surveys) {
 
-    public static ApplicationDetailResponse from(SurveyResults surveyResults) {
+    public static ApplicationDetailResponse from(List<SurveyResult> surveyResults) {
         return new ApplicationDetailResponse(
-                surveyResults.getValues().stream()
+                surveyResults.stream()
                         .map(SurveyResultResponse::from)
                         .toList());
     }

--- a/src/main/java/dev/steady/application/exception/SurveyResultErrorCode.java
+++ b/src/main/java/dev/steady/application/exception/SurveyResultErrorCode.java
@@ -1,0 +1,26 @@
+package dev.steady.application.exception;
+
+import dev.steady.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SurveyResultErrorCode implements ErrorCode {
+
+    INVALID_SURVEY_SIZE("SU00", "신청서에 접근 권한이 없습니다.");
+
+    private final String errorCode;
+    private final String message;
+
+    @Override
+    public String code() {
+        return this.errorCode;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+
+}

--- a/src/main/java/dev/steady/application/service/ApplicationService.java
+++ b/src/main/java/dev/steady/application/service/ApplicationService.java
@@ -97,7 +97,7 @@ public class ApplicationService {
     public void updateApplicationAnswer(Long applicationId, ApplicationUpdateAnswerRequest request, UserInfo userInfo) {
         User user = userRepository.getUserBy(userInfo.userId());
         Application application = applicationRepository.getById(applicationId);
-        application.validateApplicantOrThrow(user);
+        application.validateUpdateAnswer(user);
 
         List<SurveyResult> surveyResult = surveyResultRepository.findByApplicationOrderBySequenceAsc(application);
         SurveyResults surveyResults = new SurveyResults(surveyResult);

--- a/src/main/java/dev/steady/application/service/ApplicationService.java
+++ b/src/main/java/dev/steady/application/service/ApplicationService.java
@@ -93,6 +93,17 @@ public class ApplicationService {
         createNotification(new ApplicationResultNotificationStrategy(application));
     }
 
+    @Transactional
+    public void updateApplicationAnswer(Long applicationId, ApplicationUpdateAnswerRequest request, UserInfo userInfo) {
+        User user = userRepository.getUserBy(userInfo.userId());
+        Application application = applicationRepository.getById(applicationId);
+        application.validateApplicantOrThrow(user);
+
+        List<SurveyResult> surveyResult = surveyResultRepository.findByApplicationOrderBySequenceAsc(application);
+        SurveyResults surveyResults = new SurveyResults(surveyResult);
+        surveyResults.updateAnswers(request.answers());
+    }
+
     private void addParticipant(Application application, User leader) {
         Steady steady = application.getSteady();
         User user = application.getUser();

--- a/src/main/java/dev/steady/application/service/ApplicationService.java
+++ b/src/main/java/dev/steady/application/service/ApplicationService.java
@@ -4,7 +4,9 @@ import dev.steady.application.domain.Application;
 import dev.steady.application.domain.SurveyResult;
 import dev.steady.application.domain.SurveyResults;
 import dev.steady.application.domain.repository.ApplicationRepository;
+import dev.steady.application.domain.repository.SurveyResultRepository;
 import dev.steady.application.dto.request.ApplicationStatusUpdateRequest;
+import dev.steady.application.dto.request.ApplicationUpdateAnswerRequest;
 import dev.steady.application.dto.request.SurveyResultRequest;
 import dev.steady.application.dto.response.ApplicationDetailResponse;
 import dev.steady.application.dto.response.ApplicationSummaryResponse;
@@ -40,6 +42,7 @@ public class ApplicationService {
     private final UserRepository userRepository;
     private final SteadyRepository steadyRepository;
     private final ApplicationRepository applicationRepository;
+    private final SurveyResultRepository surveyResultRepository;
     private final NotificationService notificationService;
 
     @Transactional
@@ -48,9 +51,11 @@ public class ApplicationService {
         Steady steady = steadyRepository.getSteady(steadyId);
 
         Application application = new Application(user, steady);
-        createSurveyResult(application, request);
-
         Application savedApplication = applicationRepository.save(application);
+
+        List<SurveyResult> surveyResult = createSurveyResult(application, request);
+        surveyResultRepository.saveAll(surveyResult);
+
         createNotification(new FreshApplicationNotificationStrategy(steady));
         return CreateApplicationResponse.from(savedApplication);
     }
@@ -71,7 +76,7 @@ public class ApplicationService {
         Application application = applicationRepository.getById(applicationId);
         application.checkAccessOrThrow(user);
 
-        SurveyResults surveyResults = application.getSurveyResults();
+        List<SurveyResult> surveyResults = surveyResultRepository.findByApplicationOrderBySequenceAsc(application);
         return ApplicationDetailResponse.from(surveyResults);
     }
 

--- a/src/test/java/dev/steady/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/dev/steady/application/controller/ApplicationControllerTest.java
@@ -15,6 +15,7 @@ import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resour
 import static dev.steady.application.domain.ApplicationStatus.ACCEPTED;
 import static dev.steady.application.fixture.ApplicationFixture.createApplicationDetailResponse;
 import static dev.steady.application.fixture.ApplicationFixture.createApplicationSummaryResponse;
+import static dev.steady.application.fixture.SurveyResultFixture.createAnswers;
 import static dev.steady.application.fixture.SurveyResultFixture.createSurveyResultRequests;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -172,6 +173,32 @@ class ApplicationControllerTest extends ControllerTestConfig {
                                 )
                         )
                 ).andExpect(status().isNoContent());
+    }
+
+    @DisplayName("신청자는 본인이 제출한 신청서의 답변을 수정할 수 있다.")
+    @Test
+    void updateApplicationAnswersTest() throws Exception {
+        long userId = 1L;
+        long applicationId = 1L;
+        var request = createAnswers();
+        var auth = new Authentication(userId);
+
+        when(jwtResolver.getAuthentication(TOKEN)).thenReturn(auth);
+
+        mockMvc.perform(patch("/api/v1/applications/{applicationId}", applicationId)
+                .contentType(APPLICATION_JSON)
+                .header(AUTHORIZATION, TOKEN)
+                .content(objectMapper.writeValueAsString(request))
+        ).andDo(document("application-answer-update",
+                resourceDetails().tag("신청서").description("신청서 답변 수정")
+                        .requestSchema(Schema.schema("ApplicationUpdateAnswerRequest")),
+                requestHeaders(
+                        headerWithName(AUTHORIZATION).description("토큰")
+                ),
+                requestFields(
+                        fieldWithPath("answers").type(ARRAY).description("답변 목록")
+                )
+        )).andExpect(status().isNoContent());
     }
 
 }

--- a/src/test/java/dev/steady/application/fixture/ApplicationFixture.java
+++ b/src/test/java/dev/steady/application/fixture/ApplicationFixture.java
@@ -15,7 +15,6 @@ public class ApplicationFixture {
 
     public static Application createApplication(User user, Steady steady) {
         Application application = new Application(user, steady);
-        saveSurveyResults(application);
         return application;
     }
 
@@ -38,10 +37,10 @@ public class ApplicationFixture {
         );
     }
 
-    private static void saveSurveyResults(Application application) {
-        List.of(SurveyResult.create(application, "질문1", "질문1", 0),
-                SurveyResult.create(application, "질문2", "질문2", 1),
-                SurveyResult.create(application, "질문3", "질문3", 2)
+    public static List<SurveyResult> createSurveyResults(Application application) {
+        return List.of(SurveyResult.create(application, "질문1", "답변1", 0),
+                SurveyResult.create(application, "질문2", "답변2", 1),
+                SurveyResult.create(application, "질문3", "답변3", 2)
         );
     }
 

--- a/src/test/java/dev/steady/application/fixture/SurveyResultFixture.java
+++ b/src/test/java/dev/steady/application/fixture/SurveyResultFixture.java
@@ -1,5 +1,6 @@
 package dev.steady.application.fixture;
 
+import dev.steady.application.dto.request.ApplicationUpdateAnswerRequest;
 import dev.steady.application.dto.request.SurveyResultRequest;
 
 import java.util.List;
@@ -12,6 +13,12 @@ public class SurveyResultFixture {
                 new SurveyResultRequest("질문2", "답변2"),
                 new SurveyResultRequest("질문3", "답변3")
         );
+    }
+
+    public static ApplicationUpdateAnswerRequest createAnswers() {
+        return new ApplicationUpdateAnswerRequest(List.of(
+                "답변100", "답변101", "답변102"
+        ));
     }
 
 }

--- a/src/test/java/dev/steady/application/service/ApplicationServiceTest.java
+++ b/src/test/java/dev/steady/application/service/ApplicationServiceTest.java
@@ -2,12 +2,15 @@ package dev.steady.application.service;
 
 import dev.steady.application.domain.Application;
 import dev.steady.application.domain.ApplicationStatus;
+import dev.steady.application.domain.SurveyResult;
 import dev.steady.application.domain.repository.ApplicationRepository;
+import dev.steady.application.domain.repository.SurveyResultRepository;
 import dev.steady.application.dto.request.ApplicationStatusUpdateRequest;
 import dev.steady.application.dto.response.ApplicationDetailResponse;
 import dev.steady.application.dto.response.ApplicationSummaryResponse;
 import dev.steady.application.dto.response.CreateApplicationResponse;
 import dev.steady.application.dto.response.SliceResponse;
+import dev.steady.global.auth.UserInfo;
 import dev.steady.global.exception.ForbiddenException;
 import dev.steady.notification.domain.repository.NotificationRepository;
 import dev.steady.steady.domain.repository.SteadyRepository;
@@ -31,6 +34,8 @@ import java.util.List;
 import static dev.steady.application.domain.ApplicationStatus.ACCEPTED;
 import static dev.steady.application.domain.ApplicationStatus.REJECTED;
 import static dev.steady.application.fixture.ApplicationFixture.createApplication;
+import static dev.steady.application.fixture.ApplicationFixture.createSurveyResults;
+import static dev.steady.application.fixture.SurveyResultFixture.createAnswers;
 import static dev.steady.application.fixture.SurveyResultFixture.createSurveyResultRequests;
 import static dev.steady.global.auth.AuthFixture.createUserInfo;
 import static dev.steady.steady.fixture.SteadyFixtures.createSteady;
@@ -66,6 +71,9 @@ class ApplicationServiceTest {
     private ApplicationRepository applicationRepository;
 
     @Autowired
+    private SurveyResultRepository surveyResultRepository;
+
+    @Autowired
     private NotificationRepository notificationRepository;
 
     private Position position;
@@ -82,6 +90,7 @@ class ApplicationServiceTest {
     @AfterEach
     void tearDown() {
         notificationRepository.deleteAll();
+        surveyResultRepository.deleteAll();
         applicationRepository.deleteAll();
         steadyRepository.deleteAll();
         userRepository.deleteAll();
@@ -93,10 +102,9 @@ class ApplicationServiceTest {
     @Test
     void createApplicationTest() {
         //given
-        var user = userRepository.save(createSecondUser(position));
-        var steady = steadyRepository.save(createSteady(user, stack));
+        var steady = steadyRepository.save(createSteady(leader, stack));
         var surveyResultRequests = createSurveyResultRequests();
-        var userInfo = createUserInfo(user.getId());
+        var userInfo = createUserInfo(leader.getId());
 
         //when
         CreateApplicationResponse response = applicationService.createApplication(steady.getId(),
@@ -154,6 +162,7 @@ class ApplicationServiceTest {
         var steady = steadyRepository.save(createSteady(leader, stack));
         var secondUser = userRepository.save(createSecondUser(position));
         var application = applicationRepository.save(createApplication(secondUser, steady));
+        surveyResultRepository.saveAll(createSurveyResults(application));
         var userInfo = createUserInfo(leader.getId());
         //when
         ApplicationDetailResponse response = applicationService.getApplicationDetail(application.getId(), userInfo);
@@ -161,9 +170,9 @@ class ApplicationServiceTest {
         assertThat(response.surveys()).hasSize(3)
                 .extracting("question", "answer")
                 .containsExactly(
-                        tuple("질문1", "질문1"),
-                        tuple("질문2", "질문2"),
-                        tuple("질문3", "질문3")
+                        tuple("질문1", "답변1"),
+                        tuple("질문2", "답변2"),
+                        tuple("질문3", "답변3")
                 );
     }
 
@@ -215,6 +224,48 @@ class ApplicationServiceTest {
         assertThatThrownBy(() -> {
             applicationService.updateStatusOfApplication(application.getId(), request, userInfo);
         }).isInstanceOf(ForbiddenException.class);
+    }
+
+    @DisplayName("신청자는 본인이 제출한 신청서의 답변을 수정할 수 있다.")
+    @Test
+    void updateApplicationAnswerTest() {
+        //given
+        var steady = steadyRepository.save(createSteady(leader, stack));
+        var secondUser = userRepository.save(createSecondUser(position));
+        var application = createApplication(secondUser, steady);
+        var savedApplication = applicationRepository.save(application);
+        surveyResultRepository.saveAll(createSurveyResults(savedApplication));
+        var applicationId = savedApplication.getId();
+        var answers = createAnswers();
+        var userInfo = new UserInfo(secondUser.getId());
+
+        //when
+        applicationService.updateApplicationAnswer(applicationId, answers, userInfo);
+
+        //then
+        List<SurveyResult> surveyResults = surveyResultRepository.findByApplicationOrderBySequenceAsc(savedApplication);
+        assertThat(surveyResults).hasSameSizeAs(answers.answers())
+                .extracting("answer")
+                .containsExactly("답변100", "답변101", "답변102");
+    }
+
+    @DisplayName("신청자는 본인이 제출한 신청서의 답변을 수정할 수 있다.")
+    @Test
+    void updateApplicationAnswerTest2() {
+        //given
+        var steady = steadyRepository.save(createSteady(leader, stack));
+        var secondUser = userRepository.save(createSecondUser(position));
+        var application = createApplication(secondUser, steady);
+        var savedApplication = applicationRepository.save(application);
+        surveyResultRepository.saveAll(createSurveyResults(savedApplication));
+        var applicationId = savedApplication.getId();
+        var answers = createAnswers();
+        var userInfo = new UserInfo(leader.getId());
+
+        //when
+        //then
+        assertThatThrownBy(() -> applicationService.updateApplicationAnswer(applicationId, answers, userInfo))
+                .isInstanceOf(ForbiddenException.class);
     }
 
 }

--- a/src/test/java/dev/steady/notification/service/NotificationServiceTest.java
+++ b/src/test/java/dev/steady/notification/service/NotificationServiceTest.java
@@ -2,6 +2,7 @@ package dev.steady.notification.service;
 
 import dev.steady.application.domain.ApplicationStatus;
 import dev.steady.application.domain.repository.ApplicationRepository;
+import dev.steady.application.domain.repository.SurveyResultRepository;
 import dev.steady.application.dto.request.ApplicationStatusUpdateRequest;
 import dev.steady.application.service.ApplicationService;
 import dev.steady.global.exception.NotFoundException;
@@ -68,6 +69,9 @@ class NotificationServiceTest {
     private ApplicationRepository applicationRepository;
 
     @Autowired
+    private SurveyResultRepository surveyResultRepository;
+
+    @Autowired
     private SteadyRepository steadyRepository;
 
     private Position position;
@@ -83,6 +87,7 @@ class NotificationServiceTest {
 
     @AfterEach
     void tearDown() {
+        surveyResultRepository.deleteAll();
         applicationRepository.deleteAll();
         steadyRepository.deleteAll();
         notificationRepository.deleteAll();

--- a/src/test/java/dev/steady/template/service/TemplateServiceTest.java
+++ b/src/test/java/dev/steady/template/service/TemplateServiceTest.java
@@ -64,7 +64,6 @@ class TemplateServiceTest {
 
     @AfterEach
     void tearDown() {
-
         questionRepository.deleteAll();
         templateRepository.deleteAll();
         userRepository.deleteAll();

--- a/src/test/java/dev/steady/user/service/PositionServiceTest.java
+++ b/src/test/java/dev/steady/user/service/PositionServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import static dev.steady.user.fixture.UserFixtures.createAnotherPosition;
 import static dev.steady.user.fixture.UserFixtures.createPosition;

--- a/src/test/java/dev/steady/user/service/StackServiceTest.java
+++ b/src/test/java/dev/steady/user/service/StackServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import static dev.steady.user.fixture.UserFixtures.createAnotherStack;
 import static dev.steady.user.fixture.UserFixtures.createStack;


### PR DESCRIPTION
## ✅ PR 체크리스트
- [ ] **테스트**
- [ ] **문서화 작업**
## 💡 어떤 작업을 하셨나요?
**Issue Number** : close #143 close #139 

**작업 내용**
신청서와 설문 양방향 제거
사용자가 제출한 신청서가 아직 대기 상태라면 신청서를 수정할 수 있습니다.

## 📝리뷰어에게
신청서와 질답이 서로 양방향 관계를 갖고 있었으나 비즈니스 로직이 복잡해지면서 양방향 관계가 복잡해져 분리했습니다.
2개 이슈를 나눠서 작업하기 어려워 함께 작업해서 1개의 PR로 올렸습니다.
