### PR TITLE
[5차 스프린트 - Review] 리뷰 카드 조회 기능 수정

### DIFF
--- a/src/main/java/dev/steady/review/domain/Card.java
+++ b/src/main/java/dev/steady/review/domain/Card.java
@@ -24,8 +24,12 @@ public class Card {
     @Column(nullable = false)
     private String content;
 
-    public Card(String content) {
+    @Column(nullable = false)
+    private String imageUrl;
+
+    public Card(String content, String imageUrl) {
         this.content = content;
+        this.imageUrl = imageUrl;
     }
 
 }

--- a/src/main/java/dev/steady/review/domain/Review.java
+++ b/src/main/java/dev/steady/review/domain/Review.java
@@ -38,7 +38,7 @@ public class Review extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Steady steady;
 
-    @Column(nullable = false)
+    @Column
     private String comment;
 
     @Column(nullable = false)

--- a/src/main/java/dev/steady/review/dto/response/UserCardResponse.java
+++ b/src/main/java/dev/steady/review/dto/response/UserCardResponse.java
@@ -2,7 +2,7 @@ package dev.steady.review.dto.response;
 
 public record UserCardResponse(
         Long cardId,
-        String content,
+        String imageUrl,
         Long count
 ) {
 }

--- a/src/main/java/dev/steady/review/infrastructure/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/dev/steady/review/infrastructure/ReviewQueryRepositoryImpl.java
@@ -29,6 +29,7 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
         return jpaQueryFactory.select(review.comment)
                 .from(review)
                 .where(revieweeEqualsUser(user),
+                        review.comment.isNotNull(),
                         isPublic())
                 .orderBy(review.createdAt.desc())
                 .fetch();
@@ -37,9 +38,10 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
     @Override
     public List<ReviewsBySteadyResponse> getAllReviewsByRevieweeUser(User user) {
         return jpaQueryFactory.selectFrom(steady)
-                .leftJoin(review)
+                .innerJoin(review)
                 .on(steady.id.eq(review.steady.id))
-                .where(revieweeEqualsUser(user))
+                .where(revieweeEqualsUser(user),
+                        review.comment.isNotNull())
                 .orderBy(steady.finishedAt.desc())
                 .transform(groupBy(steady.id)
                         .list(Projections.constructor(

--- a/src/main/java/dev/steady/review/infrastructure/UserCardQueryRepositoryImpl.java
+++ b/src/main/java/dev/steady/review/infrastructure/UserCardQueryRepositoryImpl.java
@@ -24,7 +24,7 @@ public class UserCardQueryRepositoryImpl implements UserCardQueryRepository {
     public List<UserCardResponse> getCardCountByUser(User user) {
         return jpaQueryFactory.select(Projections.constructor(UserCardResponse.class,
                         card.id,
-                        card.content,
+                        card.imageUrl,
                         userCard.card.count()))
                 .from(card)
                 .leftJoin(userCard)

--- a/src/main/java/dev/steady/review/service/ReviewService.java
+++ b/src/main/java/dev/steady/review/service/ReviewService.java
@@ -74,6 +74,10 @@ public class ReviewService {
 
     @Transactional
     public void createUserCards(ReviewCreateRequest request) {
+        if (request.cardsId().isEmpty()) {
+            return;
+        }
+        
         User reviewee = userRepository.getUserBy(request.revieweeId());
         List<Card> cards = getCards(request.cardsId());
         List<UserCard> userCards = cards.stream()

--- a/src/test/java/dev/steady/review/controller/ReviewControllerTest.java
+++ b/src/test/java/dev/steady/review/controller/ReviewControllerTest.java
@@ -88,6 +88,9 @@ class ReviewControllerTest extends ControllerTestConfig {
                 .andDo(document("review-v1-update",
                         resourceDetails().tag("리뷰").description("리뷰 공개 여부 수정")
                                 .responseSchema(Schema.schema("ReviewSwitchRepsonse")),
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION).description("토큰")
+                        ),
                         responseFields(
                                 fieldWithPath("isPublic").type(BOOLEAN).description("수정된 리뷰 공개 여부 상태")
                         )
@@ -114,9 +117,12 @@ class ReviewControllerTest extends ControllerTestConfig {
                 .andDo(document("review-v1-get-myAll",
                         resourceDetails().tag("리뷰").description("내가 받은 카드와 리뷰 조회")
                                 .responseSchema(Schema.schema("ReviewMyResponse")),
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION).description("토큰")
+                        ),
                         responseFields(
                                 fieldWithPath("userCards[].cardId").type(NUMBER).description("카드 식별자"),
-                                fieldWithPath("userCards[].content").type(STRING).description("카드 내용"),
+                                fieldWithPath("userCards[].imageUrl").type(STRING).description("카드 이미지 URL"),
                                 fieldWithPath("userCards[].count").type(NUMBER).description("사용자가 받은 카드 개수"),
                                 fieldWithPath("reviews[].steadyId").type(NUMBER).description("스테디 식별자"),
                                 fieldWithPath("reviews[].steadyName").type(STRING).description("스테디 이름"),

--- a/src/test/java/dev/steady/review/fixture/ReviewFixture.java
+++ b/src/test/java/dev/steady/review/fixture/ReviewFixture.java
@@ -28,7 +28,8 @@ public class ReviewFixture {
 
     public static Card createCard() {
         return new Card(
-                "이 팀원은 출석을 열심히 잘 했어요!"
+                "이 팀원은 출석을 열심히 잘 했어요!",
+                "attendance.jpg"
         );
     }
 

--- a/src/test/java/dev/steady/user/controller/UserControllerTest.java
+++ b/src/test/java/dev/steady/user/controller/UserControllerTest.java
@@ -165,7 +165,7 @@ class UserControllerTest extends ControllerTestConfig {
                                 fieldWithPath("user.stacks[].name").type(STRING).description("관심 스택 이름"),
                                 fieldWithPath("user.stacks[].imageUrl").type(STRING).description("관심 스택 이미지 URL"),
                                 fieldWithPath("userCards[].cardId").type(NUMBER).description("카드 식별자"),
-                                fieldWithPath("userCards[].content").type(STRING).description("카드 내용"),
+                                fieldWithPath("userCards[].imageUrl").type(STRING).description("카드 이미지 URL"),
                                 fieldWithPath("userCards[].count").type(NUMBER).description("사용자가 받은 카드 개수"),
                                 fieldWithPath("reviews").type(ARRAY).description("사용자가 받은 리뷰 코멘트"),
                                 fieldWithPath("isDeleted").type(BOOLEAN).description("탈퇴 유저 여부")


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] **테스트**
- [ ] **문서화 작업**
## 💡 어떤 작업을 하셨나요?
**Issue Number** : close #150

**작업 내용**
- [x] `Card` 엔티티에 `imageUrl` 필드 추가
- [x] 타인의 프로필 조회 기능/내 프로필 조회 기능에서 카드 정보에 `content` 대신 `imageUrl` 담도록 수정
- [x] 리뷰 생성 기능에서 `comment`가 `null`인 경우/`cardsId`가 비어있는 경우에 대해 처리
## 📝리뷰어에게
리뷰 생성 기능에서 `comment`가 `null`인 경우 아예 `createReview()` 메서드가 동작하지 않도록 처리 하려고 했으나, 이렇게 되면 `comment`는 남기지 않았으나 card는 보낸 경우 리뷰 제출 여부를 검증할 수 없어서 `comment`가 `null`인 리뷰 데이터를 생성하도록 했습니다.