### PR TITLE
[6차 스프린트 - Review, Steady] Review의 steady 필드 제거 및 Participant soft delete 적용

### DIFF
--- a/src/main/java/dev/steady/review/domain/Review.java
+++ b/src/main/java/dev/steady/review/domain/Review.java
@@ -2,7 +2,6 @@ package dev.steady.review.domain;
 
 import dev.steady.global.entity.BaseEntity;
 import dev.steady.steady.domain.Participant;
-import dev.steady.steady.domain.Steady;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -35,9 +34,6 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "reviewee_id")
     private Participant reviewee;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Steady steady;
-
     @Column
     private String comment;
 
@@ -47,11 +43,9 @@ public class Review extends BaseEntity {
     @Builder
     private Review(Participant reviewer,
                    Participant reviewee,
-                   Steady steady,
                    String comment) {
         this.reviewer = reviewer;
         this.reviewee = reviewee;
-        this.steady = steady;
         this.comment = comment;
         this.isPublic = true;
     }

--- a/src/main/java/dev/steady/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/dev/steady/review/domain/repository/ReviewRepository.java
@@ -4,7 +4,6 @@ import dev.steady.global.exception.NotFoundException;
 import dev.steady.review.domain.Review;
 import dev.steady.review.infrastructure.ReviewQueryRepository;
 import dev.steady.steady.domain.Participant;
-import dev.steady.steady.domain.Steady;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import static dev.steady.review.exception.ReviewErrorCode.REVIEW_NOT_FOUND;
@@ -15,8 +14,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQue
         return findById(reviewId)
                 .orElseThrow(() -> new NotFoundException(REVIEW_NOT_FOUND));
     }
-
-    boolean existsByReviewerAndRevieweeAndSteady(Participant reviewer, Participant reviewee, Steady steady);
 
     void deleteAllByReviewee(Participant participant);
 

--- a/src/main/java/dev/steady/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/dev/steady/review/dto/request/ReviewCreateRequest.java
@@ -2,7 +2,6 @@ package dev.steady.review.dto.request;
 
 import dev.steady.review.domain.Review;
 import dev.steady.steady.domain.Participant;
-import dev.steady.steady.domain.Steady;
 
 import java.util.List;
 
@@ -12,9 +11,8 @@ public record ReviewCreateRequest(
         String comment
 ) {
 
-    public Review toEntity(Participant reviewer, Participant reviewee, Steady steady) {
+    public Review toEntity(Participant reviewer, Participant reviewee) {
         return Review.builder()
-                .steady(steady)
                 .reviewer(reviewer)
                 .reviewee(reviewee)
                 .comment(comment)

--- a/src/main/java/dev/steady/review/infrastructure/ReviewQueryRepository.java
+++ b/src/main/java/dev/steady/review/infrastructure/ReviewQueryRepository.java
@@ -1,6 +1,7 @@
 package dev.steady.review.infrastructure;
 
 import dev.steady.review.dto.response.ReviewsBySteadyResponse;
+import dev.steady.steady.domain.Participant;
 import dev.steady.user.domain.User;
 
 import java.util.List;
@@ -10,5 +11,7 @@ public interface ReviewQueryRepository {
     List<String> getPublicCommentsByRevieweeUser(User user);
 
     List<ReviewsBySteadyResponse> getAllReviewsByRevieweeUser(User user);
+
+    Boolean existsReviewByReviewerAndRevieweeAndSteady(Participant reviewer, Participant reviewee, Long steadyId);
 
 }

--- a/src/main/java/dev/steady/review/infrastructure/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/dev/steady/review/infrastructure/ReviewQueryRepositoryImpl.java
@@ -63,9 +63,9 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
     @Override
     public Boolean existsReviewByReviewerAndRevieweeAndSteady(Participant reviewer, Participant reviewee, Long steadyId) {
         return jpaQueryFactory.from(review)
-                       .where(revieweeEquals(reviewee))
-                       .where(reviewerEquals(reviewer))
-                       .where(steadyIdEquals(steadyId))
+                       .where(revieweeEquals(reviewee),
+                               reviewerEquals(reviewer),
+                               steadyIdEquals(steadyId))
                        .fetchFirst() != null;
     }
 

--- a/src/main/java/dev/steady/review/service/ReviewService.java
+++ b/src/main/java/dev/steady/review/service/ReviewService.java
@@ -68,7 +68,7 @@ public class ReviewService {
             throw new InvalidStateException(REVIEW_DUPLICATE);
         }
 
-        Review review = request.toEntity(reviewer, reviewee, steady);
+        Review review = request.toEntity(reviewer, reviewee);
         Review savedReview = reviewRepository.save(review);
 
         return savedReview.getId();
@@ -141,10 +141,10 @@ public class ReviewService {
     }
 
     private boolean isAlreadyReviewed(Participant reviewer, Participant reviewee, Steady steady) {
-        return reviewRepository.existsByReviewerAndRevieweeAndSteady(
+        return reviewRepository.existsReviewByReviewerAndRevieweeAndSteady(
                 reviewer,
                 reviewee,
-                steady
+                steady.getId()
         );
     }
 

--- a/src/main/java/dev/steady/steady/domain/Participant.java
+++ b/src/main/java/dev/steady/steady/domain/Participant.java
@@ -34,10 +34,14 @@ public class Participant extends BaseEntity {
     @Column(name = "is_leader", nullable = false)
     private boolean isLeader;
 
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted;
+
     private Participant(User user, Steady steady, boolean isLeader) {
         this.user = user;
         this.steady = steady;
         this.isLeader = isLeader;
+        this.isDeleted = false;
     }
 
     public static Participant createLeader(User user, Steady steady) {
@@ -52,4 +56,8 @@ public class Participant extends BaseEntity {
         return this.user.getId();
     }
 
+    public void delete() {
+        this.isDeleted = true;
+    }
+    
 }

--- a/src/main/java/dev/steady/steady/domain/Participants.java
+++ b/src/main/java/dev/steady/steady/domain/Participants.java
@@ -35,7 +35,7 @@ public class Participants {
     }
 
     public void expel(Participant participant) {
-        steadyParticipants.remove(participant);
+        participant.delete();
     }
 
     public User getLeader() {
@@ -54,11 +54,16 @@ public class Participants {
     }
 
     public List<Participant> getAllParticipants() {
-        return steadyParticipants;
+        return steadyParticipants.stream()
+                .filter(participant -> !participant.isDeleted())
+                .toList();
     }
 
     public int getNumberOfParticipants() {
-        return steadyParticipants.size();
+        long count = steadyParticipants.stream()
+                .filter(participant -> !participant.isDeleted())
+                .count();
+        return (int) count;
     }
 
     public int getParticipantLimit() {

--- a/src/main/java/dev/steady/steady/domain/Participants.java
+++ b/src/main/java/dev/steady/steady/domain/Participants.java
@@ -34,10 +34,6 @@ public class Participants {
         steadyParticipants.add(participant);
     }
 
-    public void expel(Participant participant) {
-        participant.delete();
-    }
-
     public User getLeader() {
         return steadyParticipants.stream()
                 .filter(Participant::isLeader)

--- a/src/main/java/dev/steady/steady/domain/Steady.java
+++ b/src/main/java/dev/steady/steady/domain/Steady.java
@@ -169,6 +169,9 @@ public class Steady extends BaseEntity {
 
     public void expelParticipantByLeader(User leader, Participant participant) {
         validateLeader(leader);
+        if (finishedAt != null || isFinished()) {
+            throw new InvalidStateException(ALREADY_FINISHED);
+        }
         participants.expel(participant);
         numberOfParticipants = participants.getNumberOfParticipants();
     }

--- a/src/main/java/dev/steady/steady/domain/Steady.java
+++ b/src/main/java/dev/steady/steady/domain/Steady.java
@@ -172,7 +172,7 @@ public class Steady extends BaseEntity {
         if (finishedAt != null || isFinished()) {
             throw new InvalidStateException(ALREADY_FINISHED);
         }
-        participants.expel(participant);
+        participant.delete();
         numberOfParticipants = participants.getNumberOfParticipants();
     }
 

--- a/src/main/java/dev/steady/steady/infrastructure/SteadySearchRepositoryImpl.java
+++ b/src/main/java/dev/steady/steady/infrastructure/SteadySearchRepositoryImpl.java
@@ -85,7 +85,8 @@ public class SteadySearchRepositoryImpl implements SteadySearchRepository {
                 .where(
                         isFinishSteady(status),
                         isWorkSteady(status),
-                        isParticipantUserIdEqual(user)
+                        isParticipantUserIdEqual(user),
+                        isParticipantNotDeleted()
                 )
                 .orderBy(orderBySort(pageable.getSort(), Participant.class), steady.id.asc())
                 .offset(pageable.getOffset())
@@ -100,6 +101,10 @@ public class SteadySearchRepositoryImpl implements SteadySearchRepository {
 
     private BooleanExpression isParticipantUserIdEqual(User user) {
         return participant.user.id.eq(user.getId());
+    }
+
+    private BooleanExpression isParticipantNotDeleted() {
+        return participant.isDeleted.isFalse();
     }
 
     private BooleanExpression isFinishSteady(SteadyStatus status) {

--- a/src/test/java/dev/steady/review/fixture/ReviewFixture.java
+++ b/src/test/java/dev/steady/review/fixture/ReviewFixture.java
@@ -50,7 +50,6 @@ public class ReviewFixture {
 
     public static Review createReview(Participant reviewer, Participant reviewee, Steady steady) {
         return Review.builder()
-                .steady(steady)
                 .reviewer(reviewer)
                 .reviewee(reviewee)
                 .comment("다음에도 저랑 같이 공부해요!")


### PR DESCRIPTION
## ✅ PR 체크리스트
- [ ] **테스트**
- [ ] **문서화 작업**
## 💡 어떤 작업을 하셨나요?
**Issue Number** : close #170

**작업 내용**
- Review의 steady 필드를 제거했습니다.
- Steady participant를 추방할 때 soft delete를 적용했습니다. 
- 이에 따라 `Participants` 클래스의 `getAllParticipants`, `getNumberOfParticipants`를 수정하여 아래의 기능들도 추방된 참여자는 포함되지 않도록 했습니다.
  - 내 스테디 조회
  - 스테디 참여자 조회
  - 리뷰 대상자 조회
## 📝리뷰어에게
- `@OneToMany`를 처음 다뤄서 간과한 부분이 있을 수 있습니다..! 부족한 점은 피드백 부탁드립니다!
- 그리고 `getNumberOfParticipants`에서 형 변환을 시켜 반환하는데 괜찮은 코드인가요..? 
