### PR TITLE
[6차 스프린트 - Steady] 스테디용 Presigned URL 요청 기능 추가

### DIFF
--- a/src/main/java/dev/steady/storage/ImageUploadPurpose.java
+++ b/src/main/java/dev/steady/storage/ImageUploadPurpose.java
@@ -1,0 +1,31 @@
+package dev.steady.storage;
+
+import dev.steady.global.exception.InvalidValueException;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+import static dev.steady.storage.exception.StorageErrorCode.NOT_SUPPORTED_PURPOSE;
+
+@Getter
+public enum ImageUploadPurpose {
+
+    USER_PROFILE_IMAGE("profile", "profile/%s"),
+    STEADY_CONTENT_IMAGE("steady", "steady/content/%s");
+
+    private final String purpose;
+    private final String keyPattern;
+
+    ImageUploadPurpose(String purpose, String keyPattern) {
+        this.purpose = purpose;
+        this.keyPattern = keyPattern;
+    }
+
+    public static ImageUploadPurpose from(String purpose) {
+        return Arrays.stream(ImageUploadPurpose.values())
+                .filter(v -> v.getPurpose().equals(purpose))
+                .findAny()
+                .orElseThrow(() -> new InvalidValueException(NOT_SUPPORTED_PURPOSE));
+    }
+
+}

--- a/src/main/java/dev/steady/storage/controller/StorageImageController.java
+++ b/src/main/java/dev/steady/storage/controller/StorageImageController.java
@@ -1,0 +1,32 @@
+package dev.steady.storage.controller;
+
+import dev.steady.global.auth.Auth;
+import dev.steady.global.auth.UserInfo;
+import dev.steady.storage.ImageUploadPurpose;
+import dev.steady.storage.service.StorageService;
+import dev.steady.user.dto.response.PutObjectUrlResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/storage/image")
+public class StorageImageController {
+
+    private final StorageService storageService;
+
+    @GetMapping("/{purpose}")
+    public ResponseEntity<PutObjectUrlResponse> getImageUploadUrl(@PathVariable String purpose,
+                                                                  @RequestParam String fileName,
+                                                                  @Auth UserInfo userInfo) {
+        String keyPattern = ImageUploadPurpose.from(purpose).getKeyPattern();
+        PutObjectUrlResponse response = storageService.generatePutObjectUrl(fileName, keyPattern);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/dev/steady/storage/exception/StorageErrorCode.java
+++ b/src/main/java/dev/steady/storage/exception/StorageErrorCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum StorageErrorCode implements ErrorCode {
 
-    NOT_SUPPORTED_FILE_TYPE("ST01", "지원하지 않는 파일 유형입니다.");
+    NOT_SUPPORTED_FILE_TYPE("ST01", "지원하지 않는 파일 유형입니다."),
+    NOT_SUPPORTED_PURPOSE("ST02", "지원하지 않는 용도입니다.");
 
     private final String code;
     private final String message;
@@ -22,5 +23,5 @@ public enum StorageErrorCode implements ErrorCode {
     public String message() {
         return this.message;
     }
-    
+
 }

--- a/src/main/java/dev/steady/storage/service/StorageService.java
+++ b/src/main/java/dev/steady/storage/service/StorageService.java
@@ -1,4 +1,4 @@
-package dev.steady.storage;
+package dev.steady.storage.service;
 
 import dev.steady.global.exception.InvalidValueException;
 import dev.steady.user.dto.response.PutObjectUrlResponse;

--- a/src/main/java/dev/steady/user/controller/UserController.java
+++ b/src/main/java/dev/steady/user/controller/UserController.java
@@ -7,7 +7,6 @@ import dev.steady.global.auth.Auth;
 import dev.steady.global.auth.UserInfo;
 import dev.steady.user.dto.request.UserCreateRequest;
 import dev.steady.user.dto.request.UserUpdateRequest;
-import dev.steady.user.dto.response.PutObjectUrlResponse;
 import dev.steady.user.dto.response.UserMyDetailResponse;
 import dev.steady.user.dto.response.UserNicknameExistResponse;
 import dev.steady.user.dto.response.UserOtherDetailResponse;
@@ -73,12 +72,6 @@ public class UserController {
     public ResponseEntity<Void> withdrawUser(@Auth UserInfo userInfo) {
         userService.withdrawUser(userInfo);
         return ResponseEntity.noContent().build();
-    }
-
-    @GetMapping("/profile/image")
-    public ResponseEntity<PutObjectUrlResponse> getProfileUploadUrl(@RequestParam String fileName) {
-        PutObjectUrlResponse response = userService.getProfileUploadUrl(fileName);
-        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/dev/steady/user/service/UserService.java
+++ b/src/main/java/dev/steady/user/service/UserService.java
@@ -8,7 +8,7 @@ import dev.steady.review.domain.repository.UserCardRepository;
 import dev.steady.review.dto.response.UserCardResponse;
 import dev.steady.steady.domain.Participant;
 import dev.steady.steady.domain.repository.ParticipantRepository;
-import dev.steady.storage.StorageService;
+import dev.steady.storage.service.StorageService;
 import dev.steady.user.domain.Position;
 import dev.steady.user.domain.Stack;
 import dev.steady.user.domain.User;
@@ -19,7 +19,6 @@ import dev.steady.user.domain.repository.UserRepository;
 import dev.steady.user.domain.repository.UserStackRepository;
 import dev.steady.user.dto.request.UserCreateRequest;
 import dev.steady.user.dto.request.UserUpdateRequest;
-import dev.steady.user.dto.response.PutObjectUrlResponse;
 import dev.steady.user.dto.response.UserDetailResponse;
 import dev.steady.user.dto.response.UserMyDetailResponse;
 import dev.steady.user.dto.response.UserNicknameExistResponse;
@@ -115,10 +114,6 @@ public class UserService {
         List<Participant> participants = participantRepository.findByUser(user);
         participants.forEach(reviewRepository::deleteAllByReviewee);
         accountRepository.deleteByUser(user);
-    }
-
-    public PutObjectUrlResponse getProfileUploadUrl(String fileName) {
-        return storageService.generatePutObjectUrl(fileName, PROFILE_IMAGE_KEY_PATTERN);
     }
 
     private Stack getStack(Long stackId) {

--- a/src/test/java/dev/steady/global/config/ControllerTestConfig.java
+++ b/src/test/java/dev/steady/global/config/ControllerTestConfig.java
@@ -17,6 +17,8 @@ import dev.steady.steady.controller.SteadyController;
 import dev.steady.steady.controller.SteadyLikeController;
 import dev.steady.steady.service.SteadyLikeService;
 import dev.steady.steady.service.SteadyService;
+import dev.steady.storage.controller.StorageImageController;
+import dev.steady.storage.service.StorageService;
 import dev.steady.template.controller.TemplateController;
 import dev.steady.template.service.TemplateService;
 import dev.steady.user.controller.PositionController;
@@ -51,6 +53,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         PositionController.class,
         NotificationController.class,
         ReviewController.class,
+        StorageImageController.class,
         AuthContext.class,
         JwtResolver.class,
         JwtProperties.class,
@@ -87,6 +90,8 @@ public abstract class ControllerTestConfig {
     protected NotificationService notificationService;
     @MockBean
     protected ReviewService reviewService;
+    @MockBean
+    protected StorageService storageService;
     @MockBean
     protected JwtResolver jwtResolver;
 

--- a/src/test/java/dev/steady/storage/controller/StorageImageControllerTest.java
+++ b/src/test/java/dev/steady/storage/controller/StorageImageControllerTest.java
@@ -1,0 +1,68 @@
+package dev.steady.storage.controller;
+
+import com.epages.restdocs.apispec.Schema;
+import dev.steady.global.auth.Authentication;
+import dev.steady.global.config.ControllerTestConfig;
+import dev.steady.storage.ImageUploadPurpose;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
+import static dev.steady.global.auth.AuthFixture.createUserInfo;
+import static dev.steady.storage.fixture.StorageFixture.createPutObjectUrlResponse;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class StorageImageControllerTest extends ControllerTestConfig {
+
+    @ParameterizedTest
+    @EnumSource(ImageUploadPurpose.class)
+    @DisplayName("이미지 업로드용 Presigned Url을 반환할 수 있다.")
+    void getImageUploadUrl(ImageUploadPurpose imageUploadPurpose) throws Exception {
+        // given
+        var userId = 1L;
+        var userInfo = createUserInfo(userId);
+        var authentication = new Authentication(userId);
+
+        given(jwtResolver.getAuthentication(TOKEN)).willReturn(authentication);
+        var response = createPutObjectUrlResponse();
+        var fileName = "image.png";
+        var purpose = imageUploadPurpose.getPurpose();
+        var keyPattern = imageUploadPurpose.getKeyPattern();
+        given(storageService.generatePutObjectUrl(fileName, keyPattern)).willReturn(response);
+
+        // when, then
+        mockMvc.perform(get("/api/v1/storage/image/{purpose}", purpose)
+                        .queryParam("fileName", fileName)
+                        .header(AUTHORIZATION, TOKEN))
+                .andDo(document("storage-v1-get-PutObjectUrlResponse",
+                        resourceDetails().tag("스토리지").description("이미지 업로드 URL 불러오기")
+                                .responseSchema(Schema.schema("PutObjectUrlResponse")),
+                        queryParameters(
+                                parameterWithName("fileName").description("확장자를 포함한 이미지 파일 이름")
+                        ),
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION).description("토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("presignedUrl").type(STRING).description("사용자 프로필 이미지 업로드 URL"),
+                                fieldWithPath("objectUrl").type(STRING).description("업로드된 이미지 URL")
+                        ))
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().string(objectMapper.writeValueAsString(response)));
+    }
+
+}

--- a/src/test/java/dev/steady/storage/fixture/StorageFixture.java
+++ b/src/test/java/dev/steady/storage/fixture/StorageFixture.java
@@ -1,0 +1,22 @@
+package dev.steady.storage.fixture;
+
+import dev.steady.user.dto.response.PutObjectUrlResponse;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class StorageFixture {
+
+    public static PutObjectUrlResponse createPutObjectUrlResponse() {
+        String presignedUrl = UriComponentsBuilder
+                .fromUriString("bucket-name.s3.region.amazonaws.com/path/{fileName}")
+                .queryParam("X-Amz-Algorithm", "{Algorithm}")
+                .queryParam("X-Amz-Date", "{Date}")
+                .queryParam("X-Amz-SignedHeaders", "{SignedHeaders}")
+                .queryParam("X-Amz-Credential", "{Credential}")
+                .queryParam("X-Amz-Expires", "{Expires}")
+                .queryParam("X-Amz-Signature", "{Signature}")
+                .build().toString();
+        String objectUrl = "https:{bucket_name}.s3.{region}.com/{key}";
+        return PutObjectUrlResponse.of(presignedUrl, objectUrl);
+    }
+
+}

--- a/src/test/java/dev/steady/user/controller/UserControllerTest.java
+++ b/src/test/java/dev/steady/user/controller/UserControllerTest.java
@@ -16,7 +16,6 @@ import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resour
 import static dev.steady.auth.domain.Platform.KAKAO;
 import static dev.steady.auth.fixture.OAuthFixture.createAuthCodeRequestUrl;
 import static dev.steady.global.auth.AuthFixture.createUserInfo;
-import static dev.steady.user.fixture.UserFixtures.createProfileUploadUrlResponse;
 import static dev.steady.user.fixture.UserFixtures.createUserCreateRequest;
 import static dev.steady.user.fixture.UserFixtures.createUserMyDetailResponse;
 import static dev.steady.user.fixture.UserFixtures.createUserOtherDetailResponse;
@@ -230,34 +229,6 @@ class UserControllerTest extends ControllerTestConfig {
                                 headerWithName(AUTHORIZATION).description("토큰")
                         )
                 )).andExpect(status().isNoContent());
-    }
-
-
-    @Test
-    @DisplayName("프로필 이미지 업로드용 Presigned Url을 반환할 수 있다.")
-    void getProfileUploadUrl() throws Exception {
-        // given
-        var response = createProfileUploadUrlResponse();
-        var fileName = "profileimage.png";
-        given(userService.getProfileUploadUrl(fileName)).willReturn(response);
-
-        // when, then
-        mockMvc.perform(get("/api/v1/user/profile/image")
-                        .queryParam("fileName", fileName)
-                )
-                .andDo(document("user-v1-get-PutObjectUrlResponse",
-                        resourceDetails().tag("사용자").description("사용자 프로필 이미지 업로드 URL 불러오기")
-                                .responseSchema(Schema.schema("PutObjectUrlResponse")),
-                        queryParameters(
-                                parameterWithName("fileName").description("확장자를 포함한 이미지 파일 이름")
-                        ),
-                        responseFields(
-                                fieldWithPath("presignedUrl").type(STRING).description("사용자 프로필 이미지 업로드 URL"),
-                                fieldWithPath("objectUrl").type(STRING).description("업로드된 이미지 URL")
-                        ))
-                )
-                .andExpect(status().isOk())
-                .andExpect(content().string(objectMapper.writeValueAsString(response)));
     }
 
 }

--- a/src/test/java/dev/steady/user/fixture/UserFixtures.java
+++ b/src/test/java/dev/steady/user/fixture/UserFixtures.java
@@ -9,13 +9,11 @@ import dev.steady.user.dto.request.UserCreateRequest;
 import dev.steady.user.dto.request.UserUpdateRequest;
 import dev.steady.user.dto.response.PositionResponse;
 import dev.steady.user.dto.response.PositionsResponse;
-import dev.steady.user.dto.response.PutObjectUrlResponse;
 import dev.steady.user.dto.response.StackResponse;
 import dev.steady.user.dto.response.StacksResponse;
 import dev.steady.user.dto.response.UserDetailResponse;
 import dev.steady.user.dto.response.UserMyDetailResponse;
 import dev.steady.user.dto.response.UserOtherDetailResponse;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
 
@@ -165,20 +163,6 @@ public class UserFixtures {
                 1L,
                 List.of(1L, 2L)
         );
-    }
-
-    public static PutObjectUrlResponse createProfileUploadUrlResponse() {
-        String presignedUrl = UriComponentsBuilder
-                .fromUriString("bucket-name.s3.region.amazonaws.com/path/{fileName}")
-                .queryParam("X-Amz-Algorithm", "{Algorithm}")
-                .queryParam("X-Amz-Date", "{Date}")
-                .queryParam("X-Amz-SignedHeaders", "{SignedHeaders}")
-                .queryParam("X-Amz-Credential", "{Credential}")
-                .queryParam("X-Amz-Expires", "{Expires}")
-                .queryParam("X-Amz-Signature", "{Signature}")
-                .build().toString();
-        String objectUrl = "https:{bucket_name}.s3.{region}.com/{key}";
-        return PutObjectUrlResponse.of(presignedUrl, objectUrl);
     }
 
 }


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] **테스트**
- [x] **문서화 작업**
## 💡 어떤 작업을 하셨나요?
**Issue Number** : close #175 

**작업 내용**
스테디 모집글에 들어갈 사진을 업로드하기 위한 presigned url을 제공하는 기능이 필요해졌습니다.
기존에는 프로필 사진 업로드용 Presigned URL 제공 기능을 `user`도메인 패키지에 두었는데 새로운 기능이 필요해지면서 presigned url 제공 기능을 각 도메인 패키지에 두지 않고 `storage` 패키지에 통합하여 하나의 controller와 service 클래스를 이용하도록 변경했습니다. 
또한 스토리지에 용도별로 폴더를 분리하여 이미지를 저장하고자 했기 때문에 key pattern이 서로 달라야 하는데, 이를 `ENUM`으로 관리하도록 구현하였습니다.

## 📝리뷰어에게
구조나 클래스명과 같은 부분에서 피드백 부탁 드립니다!🙇‍♀️