### PR TITLE
[Steady] 스테디 탈퇴 기능 추가 및 리팩토링

### DIFF
--- a/src/main/java/dev/steady/steady/controller/SteadyController.java
+++ b/src/main/java/dev/steady/steady/controller/SteadyController.java
@@ -114,7 +114,14 @@ public class SteadyController {
         return ResponseEntity.noContent().build();
     }
 
-    @PatchMapping("/{steadyId}/{memberId}")
+    @DeleteMapping("{steadyId}/withdraw")
+    public ResponseEntity<Void> withdrawSteady(@PathVariable Long steadyId,
+                               @Auth UserInfo userInfo) {
+        steadyService.withDrawSteady(steadyId, userInfo);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{steadyId}/members/{memberId}")
     public ResponseEntity<Void> expelParticipant(@PathVariable Long steadyId,
                                                  @PathVariable Long memberId,
                                                  @Auth UserInfo userInfo) {

--- a/src/main/java/dev/steady/steady/domain/Participant.java
+++ b/src/main/java/dev/steady/steady/domain/Participant.java
@@ -11,11 +11,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Participant extends BaseEntity {
 
@@ -34,14 +36,10 @@ public class Participant extends BaseEntity {
     @Column(name = "is_leader", nullable = false)
     private boolean isLeader;
 
-    @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted;
-
     private Participant(User user, Steady steady, boolean isLeader) {
         this.user = user;
         this.steady = steady;
         this.isLeader = isLeader;
-        this.isDeleted = false;
     }
 
     public static Participant createLeader(User user, Steady steady) {
@@ -52,12 +50,14 @@ public class Participant extends BaseEntity {
         return new Participant(user, steady, false);
     }
 
+    public void withdraw() {
+        steady.getParticipants().getAllParticipants().remove(this);
+        steady.updateNumberOfParticipants();
+    }
+
+
     public Long getUserId() {
         return this.user.getId();
     }
 
-    public void delete() {
-        this.isDeleted = true;
-    }
-    
 }

--- a/src/main/java/dev/steady/steady/domain/Participants.java
+++ b/src/main/java/dev/steady/steady/domain/Participants.java
@@ -51,16 +51,11 @@ public class Participants {
     }
 
     public List<Participant> getAllParticipants() {
-        return steadyParticipants.stream()
-                .filter(participant -> !participant.isDeleted())
-                .toList();
+        return steadyParticipants;
     }
 
     public int getNumberOfParticipants() {
-        long count = steadyParticipants.stream()
-                .filter(participant -> !participant.isDeleted())
-                .count();
-        return (int) count;
+        return steadyParticipants.size();
     }
 
     public int getParticipantLimit() {

--- a/src/main/java/dev/steady/steady/domain/Steady.java
+++ b/src/main/java/dev/steady/steady/domain/Steady.java
@@ -173,7 +173,7 @@ public class Steady extends BaseEntity {
     public void addParticipantByLeader(User leader, User member) {
         validateLeader(leader);
         participants.add(Participant.createMember(member, this));
-        numberOfParticipants = participants.getNumberOfParticipants();
+        updateNumberOfParticipants();
     }
 
     public void expelParticipantByLeader(User leader, Participant participant) {
@@ -181,7 +181,11 @@ public class Steady extends BaseEntity {
         if (finishedAt != null || isFinished()) {
             throw new InvalidStateException(ALREADY_FINISHED);
         }
-        participant.delete();
+        participants.getAllParticipants().remove(participant);
+        updateNumberOfParticipants();
+    }
+
+    public void updateNumberOfParticipants(){
         numberOfParticipants = participants.getNumberOfParticipants();
     }
 

--- a/src/main/java/dev/steady/steady/infrastructure/SteadyQueryRepositoryImpl.java
+++ b/src/main/java/dev/steady/steady/infrastructure/SteadyQueryRepositoryImpl.java
@@ -76,7 +76,7 @@ public class SteadyQueryRepositoryImpl implements SteadyQueryRepository {
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
 
-        Steady prevCursor = prev.isEmpty() ? null : prev.get(prev.size() - 1);
+        Steady prevCursor = prev.size() < pageable.getPageSize() + 1 ? null : prev.get(prev.size() - 1);
         return new SteadyFilterResponse(steadies, prevCursor);
     }
 

--- a/src/main/java/dev/steady/steady/infrastructure/SteadyQueryRepositoryImpl.java
+++ b/src/main/java/dev/steady/steady/infrastructure/SteadyQueryRepositoryImpl.java
@@ -94,8 +94,7 @@ public class SteadyQueryRepositoryImpl implements SteadyQueryRepository {
                 .where(
                         isFinishedSteady(status),
                         isWorkSteady(status),
-                        isParticipantUserIdEqual(user),
-                        isParticipantNotDeleted()
+                        isParticipantUserIdEqual(user)
                 )
                 .orderBy(orderBySort(pageable.getSort(), Participant.class), steady.id.asc())
                 .offset(pageable.getOffset())
@@ -122,10 +121,6 @@ public class SteadyQueryRepositoryImpl implements SteadyQueryRepository {
 
     private BooleanExpression isParticipantUserIdEqual(User user) {
         return participant.user.id.eq(user.getId());
-    }
-
-    private BooleanExpression isParticipantNotDeleted() {
-        return participant.isDeleted.isFalse();
     }
 
     private BooleanExpression isFinishedSteady(SteadyStatus status) {

--- a/src/main/java/dev/steady/steady/service/SteadyService.java
+++ b/src/main/java/dev/steady/steady/service/SteadyService.java
@@ -194,7 +194,7 @@ public class SteadyService {
         User user = userRepository.getUserBy(userInfo.userId());
         Steady steady = steadyRepository.getSteady(steadyId);
         Participant participant = participantRepository.findByUserAndSteady(user, steady);
-        participant.delete();
+        participant.withdraw();
     }
 
     @Transactional

--- a/src/main/java/dev/steady/steady/service/SteadyService.java
+++ b/src/main/java/dev/steady/steady/service/SteadyService.java
@@ -190,6 +190,14 @@ public class SteadyService {
     }
 
     @Transactional
+    public void withDrawSteady(Long steadyId, UserInfo userInfo) {
+        User user = userRepository.getUserBy(userInfo.userId());
+        Steady steady = steadyRepository.getSteady(steadyId);
+        Participant participant = participantRepository.findByUserAndSteady(user, steady);
+        participant.delete();
+    }
+
+    @Transactional
     public void expelParticipant(Long steadyId, Long memberId, UserInfo userInfo) {
         Steady steady = steadyRepository.getSteady(steadyId);
         User leader = userRepository.getUserBy(userInfo.userId());

--- a/src/test/java/dev/steady/steady/controller/SteadyControllerTest.java
+++ b/src/test/java/dev/steady/steady/controller/SteadyControllerTest.java
@@ -441,6 +441,29 @@ class SteadyControllerTest extends ControllerTestConfig {
     }
 
     @Test
+    @DisplayName("스테디 참여자가 스테디를 탈퇴할 수 있다.")
+    void withdrawSteadyTest() throws Exception {
+        // given
+        var steadyId = 1L;
+        var leaderId = 1L;
+        var authentication = new Authentication(leaderId);
+        var userInfo = createUserInfo(leaderId);
+
+        given(jwtResolver.getAuthentication(TOKEN)).willReturn(authentication);
+        willDoNothing().given(steadyService).withDrawSteady(steadyId, userInfo);
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/steadies/{steadyId}/withdraw", steadyId)
+                        .header(AUTHORIZATION, TOKEN))
+                .andDo(document("steady-withdraw",
+                        resourceDetails().tag("스테디").description("스테디 탈퇴하기"),
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION).description("토큰")
+                        )))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
     @DisplayName("스테디 리더는 스테디 참여자를 추방할 수 있다.")
     void expelParticipantTest() throws Exception {
         // given
@@ -454,7 +477,7 @@ class SteadyControllerTest extends ControllerTestConfig {
         willDoNothing().given(steadyService).expelParticipant(steadyId, memberId, userInfo);
 
         // when & then
-        mockMvc.perform(patch("/api/v1/steadies/{steadyId}/{memberId}", steadyId, memberId)
+        mockMvc.perform(delete("/api/v1/steadies/{steadyId}/members/{memberId}", steadyId, memberId)
                         .header(AUTHORIZATION, TOKEN))
                 .andDo(document("steady-expel-participant",
                         resourceDetails().tag("스테디").description("스테디 참여자 추방하기"),

--- a/src/test/java/dev/steady/steady/domain/PromotionTest.java
+++ b/src/test/java/dev/steady/steady/domain/PromotionTest.java
@@ -13,9 +13,10 @@ class PromotionTest {
     void promotionUseTest() {
         // given
         Promotion promotion = new Promotion();
-        promotion.use();
-        promotion.use();
-        promotion.use();
+        int limit = 3;
+        while (limit-- > 0) {
+            promotion.use();
+        }
 
         // when & then
         assertThatThrownBy(() -> promotion.use())

--- a/src/test/java/dev/steady/steady/service/SteadyServiceTest.java
+++ b/src/test/java/dev/steady/steady/service/SteadyServiceTest.java
@@ -465,6 +465,27 @@ class SteadyServiceTest {
     }
 
     @Test
+    @DisplayName("스테디 참여자가 스테디를 탈퇴할 수 있다.")
+    void withdrawSteadyTest() {
+        // given
+        var member = userRepository.save(generateUser(position));
+        var leaderInfo = createUserInfo(leader.getId());
+        var memberInfo = createUserInfo(member.getId());
+
+        var steadyRequest = generateSteadyCreateRequest(stack.getId(), position.getId());
+        var steadyId = steadyService.create(steadyRequest, leaderInfo);
+        var steady = steadyRepository.getSteady(steadyId);
+        steady.addParticipantByLeader(leader, member);
+
+        // when
+        steadyService.withDrawSteady(steady.getId(), memberInfo);
+
+        // then
+        Steady foundSteady = steadyRepository.getSteady(steadyId);
+        assertThat(foundSteady.getNumberOfParticipants()).isEqualTo(1);
+    }
+
+    @Test
     @DisplayName("스테디 리더가 참여자를 추방할 수 있다.")
     void expelParticipantTest() {
         // given


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] **테스트**
- [x] **문서화 작업**
## 💡 어떤 작업을 하셨나요?
**Issue Number** : #199 

**작업 내용**
- 스테디 참여자가 스테디를 탈퇴할 수 있는 기능을 추가하였습니다
- 기존의 Pagination 과정에서 이전 커서를 잘못 계산하는 부분을 수정하였습니다.
- 참여자 삭제 정책을 Soft Delete 에서 Hard Delete로 변경하였고, 이에 따라 스테디 참여자 인원 계산 방식을 변경하였습니다.

## 📝리뷰어에게
- 기존의 참여자 삭제 정책을 Soft Delete로 책정하였었는데, 참여자에 대한 정보를 따로 보관할 이유가 없다고 판단하여 Hard Delete로 변경하였습니다. 
- 또한 논리적 삭제인 경우 DB에서 데이터를 지우는 것이 아니라는 근거로 `PATCH` 메서드를 사용하게끔 API를 작성하였었는데, 해당 부분에 대해 다시 공부해본 결과 논리적 삭제 물리적 삭제와 관계 없이 서비스 입장에서 바라봤을 때는 삭제라는 명확한 행위를 호출하는 것이기 때문에 DELETE 메서드로 변경하였습니다.